### PR TITLE
Add Lesson Plan with scheduling, student attendance, and automatic status

### DIFF
--- a/src/TeacherSuite.Application/Common/Interfaces/IApplicationDbContext.cs
+++ b/src/TeacherSuite.Application/Common/Interfaces/IApplicationDbContext.cs
@@ -19,6 +19,8 @@ public interface IApplicationDbContext
     DbSet<SuggestionVote> SuggestionVotes { get; }
     DbSet<RequirementIcon> RequirementIcons { get; }
     DbSet<LessonRequirementIcon> LessonRequirementIcons { get; }
+    DbSet<ScheduledLesson> ScheduledLessons { get; }
+    DbSet<StudentLessonAttendance> StudentLessonAttendances { get; }
 
     Task<int> SaveChangesAsync(CancellationToken cancellationToken);
 }

--- a/src/TeacherSuite.Application/LessonPlan/Commands/CreateScheduledLesson/CreateScheduledLesson.cs
+++ b/src/TeacherSuite.Application/LessonPlan/Commands/CreateScheduledLesson/CreateScheduledLesson.cs
@@ -1,0 +1,50 @@
+using TeacherSuite.Application.Common;
+using TeacherSuite.Application.Common.Interfaces;
+using TeacherSuite.Domain.Common;
+using TeacherSuite.Domain.Entities;
+
+namespace TeacherSuite.Application.LessonPlan.Commands.CreateScheduledLesson;
+
+[Authorize(AppRoles.Policies.AdminSupervisorOrTeacher)]
+public record CreateScheduledLessonCommand(int LessonId, Guid GroupId, DateTimeOffset ScheduledStart) : IRequest<Guid>;
+
+internal sealed class CreateScheduledLessonCommandHandler(IApplicationDbContext db) : IRequestHandler<CreateScheduledLessonCommand, Guid>
+{
+    public async Task<Guid> Handle(CreateScheduledLessonCommand request, CancellationToken cancellationToken)
+    {
+        var lesson = await db.Lessons.FindAsync(new object[] { request.LessonId }, cancellationToken);
+        Guard.Against.NotFound(request.LessonId, lesson);
+
+        var groupAssigned = await db.GroupCourses
+            .AnyAsync(gc => gc.GroupId == request.GroupId && gc.CourseId == lesson.CourseId, cancellationToken);
+
+        if (!groupAssigned)
+        {
+            throw new ConflictException("The group is not assigned to this lesson's course.");
+        }
+
+        var overlapping = await db.ScheduledLessons
+            .AnyAsync(sl => sl.LessonId == request.LessonId
+                && sl.GroupId == request.GroupId
+                && sl.ScheduledStart == request.ScheduledStart, cancellationToken);
+
+        if (overlapping)
+        {
+            throw new ConflictException("This lesson is already scheduled for this group at the specified time.");
+        }
+
+        var entity = new ScheduledLesson
+        {
+            Id = Guid.NewGuid(),
+            LessonId = request.LessonId,
+            GroupId = request.GroupId,
+            ScheduledStart = request.ScheduledStart,
+            ScheduledEnd = request.ScheduledStart.AddMinutes(lesson.DurationMinutes)
+        };
+
+        db.ScheduledLessons.Add(entity);
+        await db.SaveChangesAsync(cancellationToken);
+
+        return entity.Id;
+    }
+}

--- a/src/TeacherSuite.Application/LessonPlan/Commands/CreateScheduledLesson/CreateScheduledLessonValidator.cs
+++ b/src/TeacherSuite.Application/LessonPlan/Commands/CreateScheduledLesson/CreateScheduledLessonValidator.cs
@@ -1,0 +1,19 @@
+namespace TeacherSuite.Application.LessonPlan.Commands.CreateScheduledLesson;
+
+public class CreateScheduledLessonCommandValidator : AbstractValidator<CreateScheduledLessonCommand>
+{
+    public CreateScheduledLessonCommandValidator()
+    {
+        RuleFor(x => x.LessonId)
+            .GreaterThan(0)
+            .WithMessage("A valid lesson is required");
+
+        RuleFor(x => x.GroupId)
+            .NotEmpty()
+            .WithMessage("A valid group is required");
+
+        RuleFor(x => x.ScheduledStart)
+            .NotEqual(default(DateTimeOffset))
+            .WithMessage("A valid scheduled start time is required");
+    }
+}

--- a/src/TeacherSuite.Application/LessonPlan/Commands/SaveAttendance/SaveAttendance.cs
+++ b/src/TeacherSuite.Application/LessonPlan/Commands/SaveAttendance/SaveAttendance.cs
@@ -1,0 +1,57 @@
+using TeacherSuite.Application.Common;
+using TeacherSuite.Application.Common.Interfaces;
+using TeacherSuite.Domain.Common;
+using TeacherSuite.Domain.Entities;
+
+namespace TeacherSuite.Application.LessonPlan.Commands.SaveAttendance;
+
+public record StudentAttendanceEntry(Guid StudentId, bool IsPresent);
+
+[Authorize(AppRoles.Policies.AdminSupervisorOrTeacher)]
+public record SaveAttendanceCommand(Guid ScheduledLessonId, List<StudentAttendanceEntry> Attendances) : IRequest;
+
+internal sealed class SaveAttendanceCommandHandler(IApplicationDbContext db) : IRequestHandler<SaveAttendanceCommand>
+{
+    public async Task Handle(SaveAttendanceCommand request, CancellationToken cancellationToken)
+    {
+        var scheduledLesson = await db.ScheduledLessons
+            .FirstOrDefaultAsync(sl => sl.Id == request.ScheduledLessonId, cancellationToken);
+
+        Guard.Against.NotFound(request.ScheduledLessonId, scheduledLesson);
+
+        var groupStudentIds = await db.StudentGroups
+            .Where(sg => sg.GroupId == scheduledLesson.GroupId)
+            .Select(sg => sg.StudentId)
+            .ToHashSetAsync(cancellationToken);
+
+        var existingAttendances = await db.StudentLessonAttendances
+            .Where(sa => sa.ScheduledLessonId == request.ScheduledLessonId)
+            .ToDictionaryAsync(sa => sa.StudentId, cancellationToken);
+
+        foreach (var entry in request.Attendances)
+        {
+            if (!groupStudentIds.Contains(entry.StudentId))
+            {
+                throw new ConflictException(
+                    $"Student '{entry.StudentId}' does not belong to the group of scheduled lesson '{request.ScheduledLessonId}'.");
+            }
+
+            if (existingAttendances.TryGetValue(entry.StudentId, out var existing))
+            {
+                existing.IsPresent = entry.IsPresent;
+            }
+            else
+            {
+                db.StudentLessonAttendances.Add(new StudentLessonAttendance
+                {
+                    Id = Guid.NewGuid(),
+                    ScheduledLessonId = request.ScheduledLessonId,
+                    StudentId = entry.StudentId,
+                    IsPresent = entry.IsPresent,
+                });
+            }
+        }
+
+        await db.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/TeacherSuite.Application/LessonPlan/Commands/ToggleStudentAttendance/ToggleStudentAttendance.cs
+++ b/src/TeacherSuite.Application/LessonPlan/Commands/ToggleStudentAttendance/ToggleStudentAttendance.cs
@@ -1,3 +1,4 @@
+using TeacherSuite.Application.Common;
 using TeacherSuite.Application.Common.Interfaces;
 using TeacherSuite.Domain.Common;
 using TeacherSuite.Domain.Entities;
@@ -15,6 +16,14 @@ internal sealed class ToggleStudentAttendanceCommandHandler(IApplicationDbContex
             .FirstOrDefaultAsync(sl => sl.Id == request.ScheduledLessonId, cancellationToken);
 
         Guard.Against.NotFound(request.ScheduledLessonId, scheduledLesson);
+
+        var studentInGroup = await db.StudentGroups
+            .AnyAsync(sg => sg.StudentId == request.StudentId && sg.GroupId == scheduledLesson.GroupId, cancellationToken);
+
+        if (!studentInGroup)
+        {
+            throw new ConflictException($"Student '{request.StudentId}' does not belong to the group of scheduled lesson '{request.ScheduledLessonId}'.");
+        }
 
         var existing = await db.StudentLessonAttendances
             .FirstOrDefaultAsync(sa => sa.ScheduledLessonId == request.ScheduledLessonId

--- a/src/TeacherSuite.Application/LessonPlan/Commands/ToggleStudentAttendance/ToggleStudentAttendance.cs
+++ b/src/TeacherSuite.Application/LessonPlan/Commands/ToggleStudentAttendance/ToggleStudentAttendance.cs
@@ -1,0 +1,43 @@
+using TeacherSuite.Application.Common.Interfaces;
+using TeacherSuite.Domain.Common;
+using TeacherSuite.Domain.Entities;
+
+namespace TeacherSuite.Application.LessonPlan.Commands.ToggleStudentAttendance;
+
+[Authorize(AppRoles.Policies.AdminSupervisorOrTeacher)]
+public record ToggleStudentAttendanceCommand(Guid ScheduledLessonId, Guid StudentId, bool IsPresent) : IRequest<Guid>;
+
+internal sealed class ToggleStudentAttendanceCommandHandler(IApplicationDbContext db) : IRequestHandler<ToggleStudentAttendanceCommand, Guid>
+{
+    public async Task<Guid> Handle(ToggleStudentAttendanceCommand request, CancellationToken cancellationToken)
+    {
+        var scheduledLesson = await db.ScheduledLessons
+            .FirstOrDefaultAsync(sl => sl.Id == request.ScheduledLessonId, cancellationToken);
+
+        Guard.Against.NotFound(request.ScheduledLessonId, scheduledLesson);
+
+        var existing = await db.StudentLessonAttendances
+            .FirstOrDefaultAsync(sa => sa.ScheduledLessonId == request.ScheduledLessonId
+                && sa.StudentId == request.StudentId, cancellationToken);
+
+        if (existing is not null)
+        {
+            existing.IsPresent = request.IsPresent;
+            await db.SaveChangesAsync(cancellationToken);
+            return existing.Id;
+        }
+
+        var entity = new StudentLessonAttendance
+        {
+            Id = Guid.NewGuid(),
+            ScheduledLessonId = request.ScheduledLessonId,
+            StudentId = request.StudentId,
+            IsPresent = request.IsPresent
+        };
+
+        db.StudentLessonAttendances.Add(entity);
+        await db.SaveChangesAsync(cancellationToken);
+
+        return entity.Id;
+    }
+}

--- a/src/TeacherSuite.Application/LessonPlan/Commands/ToggleStudentAttendance/ToggleStudentAttendanceValidator.cs
+++ b/src/TeacherSuite.Application/LessonPlan/Commands/ToggleStudentAttendance/ToggleStudentAttendanceValidator.cs
@@ -1,0 +1,15 @@
+namespace TeacherSuite.Application.LessonPlan.Commands.ToggleStudentAttendance;
+
+public class ToggleStudentAttendanceCommandValidator : AbstractValidator<ToggleStudentAttendanceCommand>
+{
+    public ToggleStudentAttendanceCommandValidator()
+    {
+        RuleFor(x => x.ScheduledLessonId)
+            .NotEmpty()
+            .WithMessage("A valid scheduled lesson is required");
+
+        RuleFor(x => x.StudentId)
+            .NotEmpty()
+            .WithMessage("A valid student is required");
+    }
+}

--- a/src/TeacherSuite.Application/LessonPlan/Dtos/ScheduledLessonDto.cs
+++ b/src/TeacherSuite.Application/LessonPlan/Dtos/ScheduledLessonDto.cs
@@ -14,6 +14,7 @@ public class ScheduledLessonDto
     public int LessonOrder { get; init; }
     public DateTimeOffset ScheduledStart { get; init; }
     public DateTimeOffset ScheduledEnd { get; init; }
+    public bool HasAttendance { get; init; }
 
     private class Mapping : Profile
     {
@@ -29,7 +30,9 @@ public class ScheduledLessonDto
                 .ForMember(dest => dest.CourseId,
                     opt => opt.MapFrom(src => src.Lesson != null ? src.Lesson.CourseId : 0))
                 .ForMember(dest => dest.LessonOrder,
-                    opt => opt.MapFrom(src => src.Lesson != null ? src.Lesson.Order : 0));
+                    opt => opt.MapFrom(src => src.Lesson != null ? src.Lesson.Order : 0))
+                .ForMember(dest => dest.HasAttendance,
+                    opt => opt.MapFrom(src => src.StudentAttendances != null && src.StudentAttendances.Count > 0));
         }
     }
 }

--- a/src/TeacherSuite.Application/LessonPlan/Dtos/ScheduledLessonDto.cs
+++ b/src/TeacherSuite.Application/LessonPlan/Dtos/ScheduledLessonDto.cs
@@ -1,0 +1,35 @@
+using TeacherSuite.Domain.Entities;
+
+namespace TeacherSuite.Application.LessonPlan.Dtos;
+
+public class ScheduledLessonDto
+{
+    public Guid Id { get; init; }
+    public int LessonId { get; init; }
+    public Guid GroupId { get; init; }
+    public string? GroupName { get; init; }
+    public string LessonTitle { get; init; } = string.Empty;
+    public string? CourseName { get; init; }
+    public int CourseId { get; init; }
+    public int LessonOrder { get; init; }
+    public DateTimeOffset ScheduledStart { get; init; }
+    public DateTimeOffset ScheduledEnd { get; init; }
+
+    private class Mapping : Profile
+    {
+        public Mapping()
+        {
+            CreateMap<ScheduledLesson, ScheduledLessonDto>()
+                .ForMember(dest => dest.GroupName,
+                    opt => opt.MapFrom(src => src.Group != null ? src.Group.Name : null))
+                .ForMember(dest => dest.LessonTitle,
+                    opt => opt.MapFrom(src => src.Lesson != null ? src.Lesson.Title : string.Empty))
+                .ForMember(dest => dest.CourseName,
+                    opt => opt.MapFrom(src => src.Lesson != null && src.Lesson.Course != null ? src.Lesson.Course.Name : null))
+                .ForMember(dest => dest.CourseId,
+                    opt => opt.MapFrom(src => src.Lesson != null ? src.Lesson.CourseId : 0))
+                .ForMember(dest => dest.LessonOrder,
+                    opt => opt.MapFrom(src => src.Lesson != null ? src.Lesson.Order : 0));
+        }
+    }
+}

--- a/src/TeacherSuite.Application/LessonPlan/Dtos/StudentAttendanceDto.cs
+++ b/src/TeacherSuite.Application/LessonPlan/Dtos/StudentAttendanceDto.cs
@@ -1,0 +1,24 @@
+using TeacherSuite.Domain.Entities;
+
+namespace TeacherSuite.Application.LessonPlan.Dtos;
+
+public class StudentAttendanceDto
+{
+    public Guid Id { get; init; }
+    public Guid StudentId { get; init; }
+    public string StudentFirstName { get; init; } = string.Empty;
+    public string StudentLastName { get; init; } = string.Empty;
+    public bool IsPresent { get; init; }
+
+    private class Mapping : Profile
+    {
+        public Mapping()
+        {
+            CreateMap<StudentLessonAttendance, StudentAttendanceDto>()
+                .ForMember(dest => dest.StudentFirstName,
+                    opt => opt.MapFrom(src => src.Student != null ? src.Student.FirstName : string.Empty))
+                .ForMember(dest => dest.StudentLastName,
+                    opt => opt.MapFrom(src => src.Student != null ? src.Student.LastName : string.Empty));
+        }
+    }
+}

--- a/src/TeacherSuite.Application/LessonPlan/Queries/GetLessonPlanQuery.cs
+++ b/src/TeacherSuite.Application/LessonPlan/Queries/GetLessonPlanQuery.cs
@@ -1,0 +1,50 @@
+using TeacherSuite.Application.Common.Interfaces;
+using TeacherSuite.Application.LessonPlan.Dtos;
+using TeacherSuite.Domain.Common;
+
+namespace TeacherSuite.Application.LessonPlan.Queries;
+
+[Authorize(AppRoles.Policies.AdminSupervisorOrTeacher)]
+public record GetLessonPlanQuery(DateTimeOffset? From, DateTimeOffset? To) : IRequest<List<ScheduledLessonDto>>;
+
+internal sealed class GetLessonPlanQueryHandler(
+    IApplicationDbContext db,
+    IMapper mapper,
+    ICurrentUserService currentUser) : IRequestHandler<GetLessonPlanQuery, List<ScheduledLessonDto>>
+{
+    public async Task<List<ScheduledLessonDto>> Handle(GetLessonPlanQuery request, CancellationToken cancellationToken)
+    {
+        var query = db.ScheduledLessons
+            .Include(sl => sl.Lesson)
+                .ThenInclude(l => l!.Course)
+            .Include(sl => sl.Group)
+            .AsQueryable();
+
+        // Teacher-only users see only their own groups
+        bool isTeacherOnly = currentUser.IsInRole(AppRoles.Teacher)
+            && !currentUser.IsInRole(AppRoles.Admin)
+            && !currentUser.IsInRole(AppRoles.Supervisor);
+
+        if (isTeacherOnly)
+        {
+            var teacher = await db.Teachers
+                .FirstOrDefaultAsync(t => t.Email == currentUser.Email, cancellationToken);
+
+            if (teacher is null)
+                return [];
+
+            query = query.Where(sl => sl.Group != null && sl.Group.TeacherId == teacher.Id);
+        }
+
+        if (request.From.HasValue)
+            query = query.Where(sl => sl.ScheduledEnd >= request.From.Value);
+
+        if (request.To.HasValue)
+            query = query.Where(sl => sl.ScheduledStart <= request.To.Value);
+
+        return await query
+            .OrderBy(sl => sl.ScheduledStart)
+            .ProjectTo<ScheduledLessonDto>(mapper.ConfigurationProvider)
+            .ToListAsync(cancellationToken);
+    }
+}

--- a/src/TeacherSuite.Application/LessonPlan/Queries/GetLessonPlanQuery.cs
+++ b/src/TeacherSuite.Application/LessonPlan/Queries/GetLessonPlanQuery.cs
@@ -14,11 +14,7 @@ internal sealed class GetLessonPlanQueryHandler(
 {
     public async Task<List<ScheduledLessonDto>> Handle(GetLessonPlanQuery request, CancellationToken cancellationToken)
     {
-        var query = db.ScheduledLessons
-            .Include(sl => sl.Lesson)
-                .ThenInclude(l => l!.Course)
-            .Include(sl => sl.Group)
-            .AsQueryable();
+        var query = db.ScheduledLessons.AsQueryable();
 
         // Teacher-only users see only their own groups
         bool isTeacherOnly = currentUser.IsInRole(AppRoles.Teacher)

--- a/src/TeacherSuite.Application/LessonPlan/Queries/GetScheduledLessonStudentsQuery.cs
+++ b/src/TeacherSuite.Application/LessonPlan/Queries/GetScheduledLessonStudentsQuery.cs
@@ -1,0 +1,56 @@
+using TeacherSuite.Application.Common.Interfaces;
+using TeacherSuite.Application.LessonPlan.Dtos;
+using TeacherSuite.Domain.Common;
+
+namespace TeacherSuite.Application.LessonPlan.Queries;
+
+[Authorize(AppRoles.Policies.AdminSupervisorOrTeacher)]
+public record GetScheduledLessonStudentsQuery(Guid ScheduledLessonId) : IRequest<List<StudentAttendanceDto>>;
+
+internal sealed class GetScheduledLessonStudentsQueryHandler(
+    IApplicationDbContext db,
+    IMapper mapper) : IRequestHandler<GetScheduledLessonStudentsQuery, List<StudentAttendanceDto>>
+{
+    public async Task<List<StudentAttendanceDto>> Handle(GetScheduledLessonStudentsQuery request, CancellationToken cancellationToken)
+    {
+        var scheduledLesson = await db.ScheduledLessons
+            .FirstOrDefaultAsync(sl => sl.Id == request.ScheduledLessonId, cancellationToken);
+
+        Guard.Against.NotFound(request.ScheduledLessonId, scheduledLesson);
+
+        // Get all students in the group
+        var groupStudents = await db.StudentGroups
+            .Where(sg => sg.GroupId == scheduledLesson.GroupId)
+            .Select(sg => sg.Student!)
+            .ToListAsync(cancellationToken);
+
+        // Get existing attendance records
+        var attendanceRecords = await db.StudentLessonAttendances
+            .Include(sa => sa.Student)
+            .Where(sa => sa.ScheduledLessonId == request.ScheduledLessonId)
+            .ToListAsync(cancellationToken);
+
+        var attendanceMap = attendanceRecords.ToDictionary(a => a.StudentId);
+
+        // Combine: return all students in the group with their attendance status
+        return groupStudents.Select(student =>
+        {
+            if (attendanceMap.TryGetValue(student.Id, out var attendance))
+            {
+                return mapper.Map<StudentAttendanceDto>(attendance);
+            }
+
+            return new StudentAttendanceDto
+            {
+                Id = Guid.Empty,
+                StudentId = student.Id,
+                StudentFirstName = student.FirstName,
+                StudentLastName = student.LastName,
+                IsPresent = false
+            };
+        })
+        .OrderBy(s => s.StudentLastName)
+        .ThenBy(s => s.StudentFirstName)
+        .ToList();
+    }
+}

--- a/src/TeacherSuite.Domain/Entities/ScheduledLesson.cs
+++ b/src/TeacherSuite.Domain/Entities/ScheduledLesson.cs
@@ -1,0 +1,15 @@
+using TeacherSuite.Domain.Common;
+
+namespace TeacherSuite.Domain.Entities;
+
+public class ScheduledLesson : BaseAuditableEntity
+{
+    public Guid Id { get; set; }
+    public int LessonId { get; set; }
+    public Lesson? Lesson { get; set; }
+    public Guid GroupId { get; set; }
+    public Group? Group { get; set; }
+    public DateTimeOffset ScheduledStart { get; set; }
+    public DateTimeOffset ScheduledEnd { get; set; }
+    public ICollection<StudentLessonAttendance> StudentAttendances { get; set; } = new List<StudentLessonAttendance>();
+}

--- a/src/TeacherSuite.Domain/Entities/StudentLessonAttendance.cs
+++ b/src/TeacherSuite.Domain/Entities/StudentLessonAttendance.cs
@@ -1,0 +1,13 @@
+using TeacherSuite.Domain.Common;
+
+namespace TeacherSuite.Domain.Entities;
+
+public class StudentLessonAttendance : BaseAuditableEntity
+{
+    public Guid Id { get; set; }
+    public Guid ScheduledLessonId { get; set; }
+    public ScheduledLesson? ScheduledLesson { get; set; }
+    public Guid StudentId { get; set; }
+    public Student? Student { get; set; }
+    public bool IsPresent { get; set; }
+}

--- a/src/TeacherSuite.Infrastructure/Configurations/ScheduledLessonConfiguration.cs
+++ b/src/TeacherSuite.Infrastructure/Configurations/ScheduledLessonConfiguration.cs
@@ -1,0 +1,47 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using TeacherSuite.Domain.Entities;
+
+namespace TeacherSuite.Infrastructure.Configurations;
+
+public class ScheduledLessonConfiguration : IEntityTypeConfiguration<ScheduledLesson>
+{
+    public void Configure(EntityTypeBuilder<ScheduledLesson> builder)
+    {
+        builder.HasKey(sl => sl.Id);
+
+        builder.HasIndex(sl => new { sl.LessonId, sl.GroupId, sl.ScheduledStart })
+               .IsUnique();
+
+        builder.HasOne(sl => sl.Lesson)
+               .WithMany()
+               .HasForeignKey(sl => sl.LessonId)
+               .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne(sl => sl.Group)
+               .WithMany()
+               .HasForeignKey(sl => sl.GroupId)
+               .OnDelete(DeleteBehavior.Cascade);
+    }
+}
+
+public class StudentLessonAttendanceConfiguration : IEntityTypeConfiguration<StudentLessonAttendance>
+{
+    public void Configure(EntityTypeBuilder<StudentLessonAttendance> builder)
+    {
+        builder.HasKey(sa => sa.Id);
+
+        builder.HasIndex(sa => new { sa.ScheduledLessonId, sa.StudentId })
+               .IsUnique();
+
+        builder.HasOne(sa => sa.ScheduledLesson)
+               .WithMany(sl => sl.StudentAttendances)
+               .HasForeignKey(sa => sa.ScheduledLessonId)
+               .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne(sa => sa.Student)
+               .WithMany()
+               .HasForeignKey(sa => sa.StudentId)
+               .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/src/TeacherSuite.Infrastructure/Data/ApplicationDbContext.cs
+++ b/src/TeacherSuite.Infrastructure/Data/ApplicationDbContext.cs
@@ -23,6 +23,8 @@ namespace TeacherSuite.Infrastructure.Data
         public DbSet<SuggestionVote> SuggestionVotes => Set<SuggestionVote>();
         public DbSet<RequirementIcon> RequirementIcons => Set<RequirementIcon>();
         public DbSet<LessonRequirementIcon> LessonRequirementIcons => Set<LessonRequirementIcon>();
+        public DbSet<ScheduledLesson> ScheduledLessons => Set<ScheduledLesson>();
+        public DbSet<StudentLessonAttendance> StudentLessonAttendances => Set<StudentLessonAttendance>();
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {

--- a/src/TeacherSuite.Infrastructure/Migrations/20260330211447_LessonsPlan.Designer.cs
+++ b/src/TeacherSuite.Infrastructure/Migrations/20260330211447_LessonsPlan.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeacherSuite.Infrastructure.Data;
@@ -11,9 +12,11 @@ using TeacherSuite.Infrastructure.Data;
 namespace TeacherSuite.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260330211447_LessonsPlan")]
+    partial class LessonsPlan
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/TeacherSuite.Infrastructure/Migrations/20260330211447_LessonsPlan.cs
+++ b/src/TeacherSuite.Infrastructure/Migrations/20260330211447_LessonsPlan.cs
@@ -1,0 +1,262 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace TeacherSuite.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class LessonsPlan : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "MarkdownContent",
+                table: "Lessons");
+
+            migrationBuilder.DropColumn(
+                name: "MaterialFileName",
+                table: "Lessons");
+
+            migrationBuilder.DropColumn(
+                name: "MaterialStorageKey",
+                table: "Lessons");
+
+            migrationBuilder.DropColumn(
+                name: "MaterialType",
+                table: "Lessons");
+
+            migrationBuilder.DropColumn(
+                name: "RequirementIcons",
+                table: "Lessons");
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "Created",
+                table: "Lessons",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)));
+
+            migrationBuilder.AddColumn<string>(
+                name: "CreatedBy",
+                table: "Lessons",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "LastModified",
+                table: "Lessons",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)));
+
+            migrationBuilder.AddColumn<string>(
+                name: "LastModifiedBy",
+                table: "Lessons",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.CreateTable(
+                name: "RequirementIcons",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Key = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    Emoji = table.Column<string>(type: "character varying(10)", maxLength: 10, nullable: false),
+                    Label = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_RequirementIcons", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ScheduledLessons",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    LessonId = table.Column<int>(type: "integer", nullable: false),
+                    GroupId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ScheduledStart = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    ScheduledEnd = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    Created = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    CreatedBy = table.Column<string>(type: "text", nullable: false),
+                    LastModified = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    LastModifiedBy = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ScheduledLessons", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ScheduledLessons_Groups_GroupId",
+                        column: x => x.GroupId,
+                        principalTable: "Groups",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_ScheduledLessons_Lessons_LessonId",
+                        column: x => x.LessonId,
+                        principalTable: "Lessons",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "LessonRequirementIcons",
+                columns: table => new
+                {
+                    LessonId = table.Column<int>(type: "integer", nullable: false),
+                    RequirementIconId = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_LessonRequirementIcons", x => new { x.LessonId, x.RequirementIconId });
+                    table.ForeignKey(
+                        name: "FK_LessonRequirementIcons_Lessons_LessonId",
+                        column: x => x.LessonId,
+                        principalTable: "Lessons",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_LessonRequirementIcons_RequirementIcons_RequirementIconId",
+                        column: x => x.RequirementIconId,
+                        principalTable: "RequirementIcons",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "StudentLessonAttendances",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    ScheduledLessonId = table.Column<Guid>(type: "uuid", nullable: false),
+                    StudentId = table.Column<Guid>(type: "uuid", nullable: false),
+                    IsPresent = table.Column<bool>(type: "boolean", nullable: false),
+                    Created = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    CreatedBy = table.Column<string>(type: "text", nullable: false),
+                    LastModified = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    LastModifiedBy = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_StudentLessonAttendances", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_StudentLessonAttendances_ScheduledLessons_ScheduledLessonId",
+                        column: x => x.ScheduledLessonId,
+                        principalTable: "ScheduledLessons",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_StudentLessonAttendances_Students_StudentId",
+                        column: x => x.StudentId,
+                        principalTable: "Students",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LessonRequirementIcons_RequirementIconId",
+                table: "LessonRequirementIcons",
+                column: "RequirementIconId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RequirementIcons_Key",
+                table: "RequirementIcons",
+                column: "Key",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ScheduledLessons_GroupId",
+                table: "ScheduledLessons",
+                column: "GroupId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ScheduledLessons_LessonId_GroupId_ScheduledStart",
+                table: "ScheduledLessons",
+                columns: new[] { "LessonId", "GroupId", "ScheduledStart" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_StudentLessonAttendances_ScheduledLessonId_StudentId",
+                table: "StudentLessonAttendances",
+                columns: new[] { "ScheduledLessonId", "StudentId" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_StudentLessonAttendances_StudentId",
+                table: "StudentLessonAttendances",
+                column: "StudentId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "LessonRequirementIcons");
+
+            migrationBuilder.DropTable(
+                name: "StudentLessonAttendances");
+
+            migrationBuilder.DropTable(
+                name: "RequirementIcons");
+
+            migrationBuilder.DropTable(
+                name: "ScheduledLessons");
+
+            migrationBuilder.DropColumn(
+                name: "Created",
+                table: "Lessons");
+
+            migrationBuilder.DropColumn(
+                name: "CreatedBy",
+                table: "Lessons");
+
+            migrationBuilder.DropColumn(
+                name: "LastModified",
+                table: "Lessons");
+
+            migrationBuilder.DropColumn(
+                name: "LastModifiedBy",
+                table: "Lessons");
+
+            migrationBuilder.AddColumn<string>(
+                name: "MarkdownContent",
+                table: "Lessons",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "MaterialFileName",
+                table: "Lessons",
+                type: "character varying(500)",
+                maxLength: 500,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "MaterialStorageKey",
+                table: "Lessons",
+                type: "character varying(500)",
+                maxLength: 500,
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "MaterialType",
+                table: "Lessons",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<string>(
+                name: "RequirementIcons",
+                table: "Lessons",
+                type: "text",
+                nullable: true);
+        }
+    }
+}

--- a/src/TeacherSuite.Infrastructure/Migrations/20260330211447_LessonsPlan.cs
+++ b/src/TeacherSuite.Infrastructure/Migrations/20260330211447_LessonsPlan.cs
@@ -11,70 +11,7 @@ namespace TeacherSuite.Infrastructure.Migrations
     {
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
-        {
-            migrationBuilder.DropColumn(
-                name: "MarkdownContent",
-                table: "Lessons");
-
-            migrationBuilder.DropColumn(
-                name: "MaterialFileName",
-                table: "Lessons");
-
-            migrationBuilder.DropColumn(
-                name: "MaterialStorageKey",
-                table: "Lessons");
-
-            migrationBuilder.DropColumn(
-                name: "MaterialType",
-                table: "Lessons");
-
-            migrationBuilder.DropColumn(
-                name: "RequirementIcons",
-                table: "Lessons");
-
-            migrationBuilder.AddColumn<DateTimeOffset>(
-                name: "Created",
-                table: "Lessons",
-                type: "timestamp with time zone",
-                nullable: false,
-                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)));
-
-            migrationBuilder.AddColumn<string>(
-                name: "CreatedBy",
-                table: "Lessons",
-                type: "text",
-                nullable: false,
-                defaultValue: "");
-
-            migrationBuilder.AddColumn<DateTimeOffset>(
-                name: "LastModified",
-                table: "Lessons",
-                type: "timestamp with time zone",
-                nullable: false,
-                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)));
-
-            migrationBuilder.AddColumn<string>(
-                name: "LastModifiedBy",
-                table: "Lessons",
-                type: "text",
-                nullable: false,
-                defaultValue: "");
-
-            migrationBuilder.CreateTable(
-                name: "RequirementIcons",
-                columns: table => new
-                {
-                    Id = table.Column<int>(type: "integer", nullable: false)
-                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
-                    Key = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
-                    Emoji = table.Column<string>(type: "character varying(10)", maxLength: 10, nullable: false),
-                    Label = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false)
-                },
-                constraints: table =>
-                {
-                    table.PrimaryKey("PK_RequirementIcons", x => x.Id);
-                });
-
+        { 
             migrationBuilder.CreateTable(
                 name: "ScheduledLessons",
                 columns: table => new
@@ -102,30 +39,6 @@ namespace TeacherSuite.Infrastructure.Migrations
                         name: "FK_ScheduledLessons_Lessons_LessonId",
                         column: x => x.LessonId,
                         principalTable: "Lessons",
-                        principalColumn: "Id",
-                        onDelete: ReferentialAction.Cascade);
-                });
-
-            migrationBuilder.CreateTable(
-                name: "LessonRequirementIcons",
-                columns: table => new
-                {
-                    LessonId = table.Column<int>(type: "integer", nullable: false),
-                    RequirementIconId = table.Column<int>(type: "integer", nullable: false)
-                },
-                constraints: table =>
-                {
-                    table.PrimaryKey("PK_LessonRequirementIcons", x => new { x.LessonId, x.RequirementIconId });
-                    table.ForeignKey(
-                        name: "FK_LessonRequirementIcons_Lessons_LessonId",
-                        column: x => x.LessonId,
-                        principalTable: "Lessons",
-                        principalColumn: "Id",
-                        onDelete: ReferentialAction.Cascade);
-                    table.ForeignKey(
-                        name: "FK_LessonRequirementIcons_RequirementIcons_RequirementIconId",
-                        column: x => x.RequirementIconId,
-                        principalTable: "RequirementIcons",
                         principalColumn: "Id",
                         onDelete: ReferentialAction.Cascade);
                 });
@@ -161,17 +74,6 @@ namespace TeacherSuite.Infrastructure.Migrations
                 });
 
             migrationBuilder.CreateIndex(
-                name: "IX_LessonRequirementIcons_RequirementIconId",
-                table: "LessonRequirementIcons",
-                column: "RequirementIconId");
-
-            migrationBuilder.CreateIndex(
-                name: "IX_RequirementIcons_Key",
-                table: "RequirementIcons",
-                column: "Key",
-                unique: true);
-
-            migrationBuilder.CreateIndex(
                 name: "IX_ScheduledLessons_GroupId",
                 table: "ScheduledLessons",
                 column: "GroupId");
@@ -198,65 +100,10 @@ namespace TeacherSuite.Infrastructure.Migrations
         protected override void Down(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.DropTable(
-                name: "LessonRequirementIcons");
-
-            migrationBuilder.DropTable(
                 name: "StudentLessonAttendances");
 
             migrationBuilder.DropTable(
-                name: "RequirementIcons");
-
-            migrationBuilder.DropTable(
                 name: "ScheduledLessons");
-
-            migrationBuilder.DropColumn(
-                name: "Created",
-                table: "Lessons");
-
-            migrationBuilder.DropColumn(
-                name: "CreatedBy",
-                table: "Lessons");
-
-            migrationBuilder.DropColumn(
-                name: "LastModified",
-                table: "Lessons");
-
-            migrationBuilder.DropColumn(
-                name: "LastModifiedBy",
-                table: "Lessons");
-
-            migrationBuilder.AddColumn<string>(
-                name: "MarkdownContent",
-                table: "Lessons",
-                type: "text",
-                nullable: true);
-
-            migrationBuilder.AddColumn<string>(
-                name: "MaterialFileName",
-                table: "Lessons",
-                type: "character varying(500)",
-                maxLength: 500,
-                nullable: true);
-
-            migrationBuilder.AddColumn<string>(
-                name: "MaterialStorageKey",
-                table: "Lessons",
-                type: "character varying(500)",
-                maxLength: 500,
-                nullable: true);
-
-            migrationBuilder.AddColumn<int>(
-                name: "MaterialType",
-                table: "Lessons",
-                type: "integer",
-                nullable: false,
-                defaultValue: 0);
-
-            migrationBuilder.AddColumn<string>(
-                name: "RequirementIcons",
-                table: "Lessons",
-                type: "text",
-                nullable: true);
         }
     }
 }

--- a/src/TeacherSuite.Web/Endpoints/LessonPlanEndpoints.cs
+++ b/src/TeacherSuite.Web/Endpoints/LessonPlanEndpoints.cs
@@ -1,0 +1,27 @@
+using MediatR;
+using TeacherSuite.Application.LessonPlan.Commands.CreateScheduledLesson;
+using TeacherSuite.Application.LessonPlan.Commands.ToggleStudentAttendance;
+using TeacherSuite.Application.LessonPlan.Queries;
+
+namespace TeacherSuite.Web.Endpoints;
+
+public static class LessonPlanEndpoints
+{
+    public static void MapLessonPlanEndpoints(this WebApplication app)
+    {
+        app.MapGet("/LessonPlan", async (LessonPlanHandler handler, ISender sender,
+                DateTimeOffset? from, DateTimeOffset? to) =>
+            await handler.GetLessonPlan(sender, from, to));
+
+        app.MapPost("/LessonPlan", async (LessonPlanHandler handler, ISender sender,
+                CreateScheduledLessonCommand command) =>
+            await handler.CreateScheduledLesson(sender, command));
+
+        app.MapGet("/LessonPlan/{id:guid}/students", async (LessonPlanHandler handler, ISender sender, Guid id) =>
+            await handler.GetScheduledLessonStudents(sender, id));
+
+        app.MapPost("/LessonPlan/{id:guid}/attendance", async (LessonPlanHandler handler, ISender sender,
+                Guid id, ToggleAttendanceRequest request) =>
+            await handler.ToggleStudentAttendance(sender, id, request));
+    }
+}

--- a/src/TeacherSuite.Web/Endpoints/LessonPlanEndpoints.cs
+++ b/src/TeacherSuite.Web/Endpoints/LessonPlanEndpoints.cs
@@ -1,5 +1,6 @@
 using MediatR;
 using TeacherSuite.Application.LessonPlan.Commands.CreateScheduledLesson;
+using TeacherSuite.Application.LessonPlan.Commands.SaveAttendance;
 using TeacherSuite.Application.LessonPlan.Commands.ToggleStudentAttendance;
 using TeacherSuite.Application.LessonPlan.Queries;
 
@@ -23,5 +24,9 @@ public static class LessonPlanEndpoints
         app.MapPost("/LessonPlan/{id:guid}/attendance", async (LessonPlanHandler handler, ISender sender,
                 Guid id, ToggleAttendanceRequest request) =>
             await handler.ToggleStudentAttendance(sender, id, request));
+
+        app.MapPost("/LessonPlan/{id:guid}/attendance/save", async (LessonPlanHandler handler, ISender sender,
+                Guid id, SaveAttendanceRequest request) =>
+            await handler.SaveAttendance(sender, id, request));
     }
 }

--- a/src/TeacherSuite.Web/Endpoints/LessonPlanHandler.cs
+++ b/src/TeacherSuite.Web/Endpoints/LessonPlanHandler.cs
@@ -1,6 +1,7 @@
 using MediatR;
 using Microsoft.AspNetCore.Http.HttpResults;
 using TeacherSuite.Application.LessonPlan.Commands.CreateScheduledLesson;
+using TeacherSuite.Application.LessonPlan.Commands.SaveAttendance;
 using TeacherSuite.Application.LessonPlan.Commands.ToggleStudentAttendance;
 using TeacherSuite.Application.LessonPlan.Dtos;
 using TeacherSuite.Application.LessonPlan.Queries;
@@ -8,6 +9,8 @@ using TeacherSuite.Application.LessonPlan.Queries;
 namespace TeacherSuite.Web.Endpoints;
 
 public record ToggleAttendanceRequest(Guid StudentId, bool IsPresent);
+public record SaveAttendanceEntry(Guid StudentId, bool IsPresent);
+public record SaveAttendanceRequest(List<SaveAttendanceEntry> Attendances);
 
 public class LessonPlanHandler
 {
@@ -33,5 +36,14 @@ public class LessonPlanHandler
     {
         var attendanceId = await sender.Send(new ToggleStudentAttendanceCommand(id, request.StudentId, request.IsPresent));
         return TypedResults.Ok(attendanceId);
+    }
+
+    public async Task<Ok> SaveAttendance(ISender sender, Guid id, SaveAttendanceRequest request)
+    {
+        var entries = request.Attendances
+            .Select(a => new StudentAttendanceEntry(a.StudentId, a.IsPresent))
+            .ToList();
+        await sender.Send(new SaveAttendanceCommand(id, entries));
+        return TypedResults.Ok();
     }
 }

--- a/src/TeacherSuite.Web/Endpoints/LessonPlanHandler.cs
+++ b/src/TeacherSuite.Web/Endpoints/LessonPlanHandler.cs
@@ -1,0 +1,37 @@
+using MediatR;
+using Microsoft.AspNetCore.Http.HttpResults;
+using TeacherSuite.Application.LessonPlan.Commands.CreateScheduledLesson;
+using TeacherSuite.Application.LessonPlan.Commands.ToggleStudentAttendance;
+using TeacherSuite.Application.LessonPlan.Dtos;
+using TeacherSuite.Application.LessonPlan.Queries;
+
+namespace TeacherSuite.Web.Endpoints;
+
+public record ToggleAttendanceRequest(Guid StudentId, bool IsPresent);
+
+public class LessonPlanHandler
+{
+    public async Task<Ok<List<ScheduledLessonDto>>> GetLessonPlan(ISender sender, DateTimeOffset? from, DateTimeOffset? to)
+    {
+        var result = await sender.Send(new GetLessonPlanQuery(from, to));
+        return TypedResults.Ok(result);
+    }
+
+    public async Task<Created<Guid>> CreateScheduledLesson(ISender sender, CreateScheduledLessonCommand command)
+    {
+        var id = await sender.Send(command);
+        return TypedResults.Created($"/LessonPlan/{id}", id);
+    }
+
+    public async Task<Ok<List<StudentAttendanceDto>>> GetScheduledLessonStudents(ISender sender, Guid id)
+    {
+        var result = await sender.Send(new GetScheduledLessonStudentsQuery(id));
+        return TypedResults.Ok(result);
+    }
+
+    public async Task<Ok<Guid>> ToggleStudentAttendance(ISender sender, Guid id, ToggleAttendanceRequest request)
+    {
+        var attendanceId = await sender.Send(new ToggleStudentAttendanceCommand(id, request.StudentId, request.IsPresent));
+        return TypedResults.Ok(attendanceId);
+    }
+}

--- a/src/TeacherSuite.Web/Program.cs
+++ b/src/TeacherSuite.Web/Program.cs
@@ -69,6 +69,7 @@ builder.Services.AddScoped<Groups>();
 builder.Services.AddScoped<ProgrammingLanguages>();
 builder.Services.AddScoped<Students>();
 builder.Services.AddScoped<Lessons>();
+builder.Services.AddScoped<LessonPlanHandler>();
 
 var app = builder.Build();
 
@@ -90,6 +91,7 @@ app.MapGroupEndpoints();
 app.MapProgrammingLanguageEndpoints();
 app.MapStudentEndpoints();
 app.MapLessonEndpoints();
+app.MapLessonPlanEndpoints();
 
 if (app.Environment.IsDevelopment())
 {

--- a/src/TeacherSuite.Web/src/teacher-suite-ui/package-lock.json
+++ b/src/TeacherSuite.Web/src/teacher-suite-ui/package-lock.json
@@ -309,7 +309,6 @@
       "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-21.0.1.tgz",
       "integrity": "sha512-3koB1xJNkqMg7g6JwH2rhQO268WjnPVA852lwoLW7wzSZRpJH0kHtZsnY9FYOC2kbmAGnCWWbnPLJ5/T1wemoA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@angular-devkit/core": "21.0.1",
         "jsonc-parser": "3.3.1",
@@ -464,7 +463,6 @@
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-21.0.1.tgz",
       "integrity": "sha512-EqdTGpFp7PVdTVztO7TB6+QxdzUbYXKKT2jwG2Gg+PIQZ2A8XrLPRmGXyH/DLlc5IhnoJlLbngmBRCLCO4xWog==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -481,7 +479,6 @@
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-21.0.1.tgz",
       "integrity": "sha512-YRzHpThgCaC9b3xzK1Wx859ePeHEPR7ewQklUB5TYbpzVacvnJo38PcSAx/nzOmgX9y4mgyros6LzECmBb8d8w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -495,7 +492,6 @@
       "integrity": "sha512-BxGLtL5bxlaaAs/kSN4oyXhMfvzqsj1Gc4Jauz39R4xtgOF5cIvjBtj6dJ9mD3PK0s6zaFi7WYd0YwWkxhjgMA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "7.28.4",
         "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -528,7 +524,6 @@
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-21.0.1.tgz",
       "integrity": "sha512-z0G9Bwzgqr0fQVbtMgqwl+SbbiqtJD7I2xT6U5p45LetKHojcfigH29dxi/vqALPwEdgb2nSIx7RqVhoyynraQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -573,7 +568,6 @@
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-21.0.1.tgz",
       "integrity": "sha512-68StH9HILKUqNhQKz6KKNHzpgk1n88CIusWlmJvnb0l6iWGf3ydq5lTMKAKiZQmSDAVP5unTGfNvIkh59GRyVg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -695,7 +689,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -1046,7 +1039,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1090,7 +1082,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1807,7 +1798,6 @@
       "integrity": "sha512-X7/+dG9SLpSzRkwgG5/xiIzW0oMrV3C0HOa7YHG1WnrLK+vCQHfte4k/T80059YBdei29RBC3s+pSMvPJDU9/A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^4.3.0",
         "@inquirer/confirm": "^5.1.19",
@@ -3826,7 +3816,6 @@
       "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-21.0.1.tgz",
       "integrity": "sha512-m7Z/gykPxOyC5Gs9nkFkGwYTc5xLNLcVkjjZPcYszycwsWBohDREjQLZzRG86AauWFYy8mBUrTF9CD63ZqYHeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@angular-devkit/core": "21.0.1",
         "@angular-devkit/schematics": "21.0.1",
@@ -3922,8 +3911,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
       "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@tufjs/canonical-json": {
       "version": "2.0.0",
@@ -4426,7 +4414,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -4591,7 +4578,6 @@
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -5288,7 +5274,6 @@
       "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",
@@ -5983,7 +5968,6 @@
       "integrity": "sha512-454TI39PeRDW1LgpyLPyURtB4Zx1tklSr6+OFOipsxGUH1WMTvk6C65JQdrj455+DP2uJ1+veBEHTGFKWVLFoA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.23",
         "@asamuzakjp/dom-selector": "^6.7.4",
@@ -6088,7 +6072,6 @@
       "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cli-truncate": "^5.0.0",
         "colorette": "^2.0.20",
@@ -7570,7 +7553,6 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -8187,8 +8169,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tuf-js": {
       "version": "4.0.0",
@@ -8226,7 +8207,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8359,7 +8339,6 @@
       "integrity": "sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -8919,7 +8898,6 @@
       "integrity": "sha512-d9B2J9Cm9dN9+6nxMnnNJKJCtcyKfnHj15N6YNJfaFHRLua/d3sRKU9RuKmO9mB0XdFtUizlxfz/VPbd3OxGhw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.14",
         "@vitest/mocker": "4.0.14",
@@ -9356,7 +9334,6 @@
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/TeacherSuite.Web/src/teacher-suite-ui/proxy.conf.json
+++ b/src/TeacherSuite.Web/src/teacher-suite-ui/proxy.conf.json
@@ -33,5 +33,10 @@
     "target": "https://localhost:7030",
     "secure": false,
     "changeOrigin": true
+  },
+  "/LessonPlan": {
+    "target": "https://localhost:7030",
+    "secure": false,
+    "changeOrigin": true
   }
 }

--- a/src/TeacherSuite.Web/src/teacher-suite-ui/src/app/app.html
+++ b/src/TeacherSuite.Web/src/teacher-suite-ui/src/app/app.html
@@ -26,6 +26,12 @@
         </a>
       </li>
       <li>
+        <a routerLink="/lesson-plan" routerLinkActive="active" class="nav-link">
+          <ng-icon name="heroCalendarDays" size="24" />
+          <span>Lesson Plan</span>
+        </a>
+      </li>
+      <li>
         <a routerLink="/groups" routerLinkActive="active" class="nav-link">
           <ng-icon name="heroUserGroup" size="24" />
           <span>Groups</span>

--- a/src/TeacherSuite.Web/src/teacher-suite-ui/src/app/app.routes.ts
+++ b/src/TeacherSuite.Web/src/teacher-suite-ui/src/app/app.routes.ts
@@ -8,6 +8,7 @@ import { ProgrammingLanguages } from './pages/programming-languages/programming-
 import { Students } from './pages/students/students';
 import { LessonsPage } from './pages/lessons/lessons';
 import { LessonDetailPage } from './pages/lesson-detail/lesson-detail';
+import { LessonPlanPage } from './pages/lesson-plan/lesson-plan';
 import { authGuard } from './auth/auth.guard';
 
 export const routes: Routes = [
@@ -16,6 +17,7 @@ export const routes: Routes = [
   { path: 'courses', component: Courses, canActivate: [authGuard] },
   { path: 'lessons', component: LessonsPage, canActivate: [authGuard] },
   { path: 'lessons/:id', component: LessonDetailPage, canActivate: [authGuard] },
+  { path: 'lesson-plan', component: LessonPlanPage, canActivate: [authGuard] },
   { path: 'groups', component: Groups, canActivate: [authGuard] },
   { path: 'students', component: Students, canActivate: [authGuard] },
   { path: 'age-groups', component: AgeGroups, canActivate: [authGuard] },

--- a/src/TeacherSuite.Web/src/teacher-suite-ui/src/app/app.ts
+++ b/src/TeacherSuite.Web/src/teacher-suite-ui/src/app/app.ts
@@ -9,12 +9,13 @@ import {
   heroUsers,
   heroCodeBracket,
   heroUserCircle,
+  heroCalendarDays,
 } from '@ng-icons/heroicons/outline';
 
 @Component({
   selector: 'app-root',
   imports: [RouterOutlet, RouterLink, RouterLinkActive, NgIconComponent],
-  providers: [provideIcons({ heroAcademicCap, heroBookOpen, heroClipboardDocumentList, heroUserGroup, heroUsers, heroCodeBracket, heroUserCircle })],
+  providers: [provideIcons({ heroAcademicCap, heroBookOpen, heroClipboardDocumentList, heroUserGroup, heroUsers, heroCodeBracket, heroUserCircle, heroCalendarDays })],
   templateUrl: './app.html',
   styleUrl: './app.scss'
 })

--- a/src/TeacherSuite.Web/src/teacher-suite-ui/src/app/pages/groups/groups.ts
+++ b/src/TeacherSuite.Web/src/teacher-suite-ui/src/app/pages/groups/groups.ts
@@ -243,8 +243,8 @@ export class Groups implements OnInit, OnDestroy {
 
   loadCourses() {
     this.groupService.getAllCourses().subscribe({
-      next: (courses) => {
-        this.courses = courses;
+      next: (courses: any) => {
+        this.courses = courses.items || courses;
         this.cdr.detectChanges();
       },
       error: (error) => {

--- a/src/TeacherSuite.Web/src/teacher-suite-ui/src/app/pages/groups/groups.ts
+++ b/src/TeacherSuite.Web/src/teacher-suite-ui/src/app/pages/groups/groups.ts
@@ -243,8 +243,12 @@ export class Groups implements OnInit, OnDestroy {
 
   loadCourses() {
     this.groupService.getAllCourses().subscribe({
-      next: (courses: any) => {
-        this.courses = courses.items || courses;
+      next: (courses: Course[] | { items: Course[] }) => {
+        if ('items' in courses) {
+          this.courses = courses.items;
+        } else {
+          this.courses = courses;
+        }
         this.cdr.detectChanges();
       },
       error: (error) => {

--- a/src/TeacherSuite.Web/src/teacher-suite-ui/src/app/pages/lesson-detail/lesson-detail.html
+++ b/src/TeacherSuite.Web/src/teacher-suite-ui/src/app/pages/lesson-detail/lesson-detail.html
@@ -1,6 +1,6 @@
 <div class="lesson-detail-page">
   <div class="page-header">
-    <button class="btn btn-secondary btn-back" (click)="goBackToLessons()">← Back to Lessons</button>
+    <button class="btn btn-secondary btn-back" (click)="goBackToLessons()">← {{ cameFromLessonPlan ? 'Back to Lesson Plan' : 'Back to Lessons' }}</button>
   </div>
 
   <div *ngIf="error" class="alert alert-error">

--- a/src/TeacherSuite.Web/src/teacher-suite-ui/src/app/pages/lesson-detail/lesson-detail.ts
+++ b/src/TeacherSuite.Web/src/teacher-suite-ui/src/app/pages/lesson-detail/lesson-detail.ts
@@ -31,6 +31,7 @@ export class LessonDetailPage implements OnInit {
   lesson: LessonDetail | null = null;
   loading = false;
   error: string | null = null;
+  cameFromLessonPlan = false;
 
   lessonFiles: LessonFile[] = [];
   rawMarkdownContent: string | null = null;
@@ -71,6 +72,8 @@ export class LessonDetailPage implements OnInit {
   }
 
   ngOnInit() {
+    this.cameFromLessonPlan = this.route.snapshot.queryParams['from'] === 'lesson-plan';
+
     this.route.params
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(params => {
@@ -179,6 +182,10 @@ export class LessonDetailPage implements OnInit {
   }
 
   goBackToLessons() {
+    if (this.cameFromLessonPlan) {
+      this.router.navigate(['/lesson-plan']);
+      return;
+    }
     if (this.lesson) {
       this.router.navigate(['/lessons'], { queryParams: { courseId: this.lesson.courseId } });
     } else {

--- a/src/TeacherSuite.Web/src/teacher-suite-ui/src/app/pages/lesson-plan/lesson-plan.html
+++ b/src/TeacherSuite.Web/src/teacher-suite-ui/src/app/pages/lesson-plan/lesson-plan.html
@@ -1,0 +1,191 @@
+<div class="lesson-plan-page">
+  <!-- Header -->
+  <div class="page-header">
+    <div class="header-content">
+      <ng-icon name="heroCalendarDays" size="32" />
+      <h1>Lesson Plan</h1>
+    </div>
+    <button class="btn-schedule" (click)="openScheduleModal()">
+      <ng-icon name="heroPlus" size="20" />
+      Schedule Lesson
+    </button>
+  </div>
+
+  <!-- Alerts -->
+  @if (error) {
+    <div class="alert alert-error">{{ error }}</div>
+  }
+  @if (success) {
+    <div class="alert alert-success">{{ success }}</div>
+  }
+
+  <!-- Loading -->
+  @if (loading) {
+    <div class="loading-grid">
+      @for (i of [1, 2, 3, 4]; track i) {
+        <div class="skeleton-card">
+          <div class="skeleton-line wide"></div>
+          <div class="skeleton-line medium"></div>
+          <div class="skeleton-line narrow"></div>
+        </div>
+      }
+    </div>
+  }
+
+  <!-- Empty State -->
+  @if (!loading && scheduledLessons.length === 0) {
+    <div class="empty-state">
+      <ng-icon name="heroCalendarDays" size="64" />
+      <h2>No scheduled lessons</h2>
+      <p>Schedule your first lesson to see it here.</p>
+    </div>
+  }
+
+  <!-- Lesson Plan Grid -->
+  @if (!loading && scheduledLessons.length > 0) {
+    <div class="lesson-plan-grid">
+      @for (lesson of scheduledLessons; track lesson.id) {
+        <div class="lesson-card" [class.status-active]="getLessonStatus(lesson) === 'active'"
+             [class.status-completed]="getLessonStatus(lesson) === 'completed'"
+             [class.status-upcoming]="getLessonStatus(lesson) === 'upcoming'">
+          <div class="card-header">
+            <span class="status-badge" [class.active]="getLessonStatus(lesson) === 'active'"
+                  [class.completed]="getLessonStatus(lesson) === 'completed'"
+                  [class.upcoming]="getLessonStatus(lesson) === 'upcoming'">
+              {{ getStatusLabel(lesson) }}
+            </span>
+            <span class="lesson-order">#{{ lesson.lessonOrder }}</span>
+          </div>
+
+          <h3 class="lesson-title">{{ lesson.lessonTitle }}</h3>
+
+          <div class="lesson-meta">
+            <div class="meta-item">
+              <ng-icon name="heroBookOpen" size="16" />
+              <span>{{ lesson.courseName }}</span>
+            </div>
+            <div class="meta-item">
+              <ng-icon name="heroUserGroup" size="16" />
+              <span>{{ lesson.groupName }}</span>
+            </div>
+            <div class="meta-item">
+              <ng-icon name="heroClock" size="16" />
+              <span>{{ formatDateTime(lesson.scheduledStart) }}</span>
+            </div>
+            <div class="meta-item time-range">
+              <span>{{ formatTime(lesson.scheduledStart) }} — {{ formatTime(lesson.scheduledEnd) }}</span>
+            </div>
+          </div>
+
+          <div class="card-actions">
+            <button class="btn-action btn-details" (click)="navigateToLesson(lesson.lessonId)">
+              <ng-icon name="heroEye" size="16" />
+              Details
+            </button>
+            <button class="btn-action btn-attendance" (click)="openAttendanceModal(lesson)">
+              <ng-icon name="heroUserGroup" size="16" />
+              Attendance
+            </button>
+          </div>
+        </div>
+      }
+    </div>
+  }
+</div>
+
+<!-- Schedule Modal -->
+@if (showScheduleModal) {
+  <div class="modal-overlay" (click)="closeScheduleModal()">
+    <div class="modal-content" (click)="$event.stopPropagation()">
+      <h2>Schedule a Lesson</h2>
+
+      <form [formGroup]="scheduleForm" (ngSubmit)="scheduleLesson()">
+        <div class="form-group">
+          <label for="courseId">Course</label>
+          <select id="courseId" formControlName="courseId" (change)="onCourseChange()">
+            <option value="">Select a course</option>
+            @for (course of courses; track course.id) {
+              <option [value]="course.id">{{ course.name }}</option>
+            }
+          </select>
+        </div>
+
+        <div class="form-group">
+          <label for="lessonId">Lesson</label>
+          <select id="lessonId" formControlName="lessonId" [disabled]="!lessons.length">
+            <option value="">Select a lesson</option>
+            @for (l of lessons; track l.id) {
+              <option [value]="l.id">#{{ l.order }} — {{ l.title }} ({{ l.durationMinutes }}min)</option>
+            }
+          </select>
+        </div>
+
+        <div class="form-group">
+          <label for="groupId">Group</label>
+          <select id="groupId" formControlName="groupId" [disabled]="!groups.length">
+            <option value="">Select a group</option>
+            @for (g of groups; track g.id) {
+              <option [value]="g.id">{{ g.name }}</option>
+            }
+          </select>
+        </div>
+
+        <div class="form-group">
+          <label for="scheduledStart">Start Time</label>
+          <input type="datetime-local" id="scheduledStart" formControlName="scheduledStart" />
+        </div>
+
+        <div class="modal-actions">
+          <button type="button" class="btn-cancel" (click)="closeScheduleModal()">Cancel</button>
+          <button type="submit" class="btn-submit" [disabled]="scheduleForm.invalid">Schedule</button>
+        </div>
+      </form>
+    </div>
+  </div>
+}
+
+<!-- Attendance Modal -->
+@if (showAttendanceModal && selectedScheduledLesson) {
+  <div class="modal-overlay" (click)="closeAttendanceModal()">
+    <div class="modal-content attendance-modal" (click)="$event.stopPropagation()">
+      <h2>Student Attendance</h2>
+      <p class="attendance-subtitle">
+        {{ selectedScheduledLesson.lessonTitle }} — {{ selectedScheduledLesson.groupName }}
+      </p>
+
+      @if (loadingAttendance) {
+        <div class="loading-spinner"></div>
+      }
+
+      @if (!loadingAttendance && studentAttendances.length === 0) {
+        <p class="no-students">No students are assigned to this group.</p>
+      }
+
+      @if (!loadingAttendance && studentAttendances.length > 0) {
+        <div class="attendance-list">
+          @for (student of studentAttendances; track student.studentId) {
+            <div class="attendance-item" [class.present]="student.isPresent"
+                 (click)="toggleAttendance(student)">
+              <div class="student-info">
+                <span class="student-name">{{ student.studentFirstName }} {{ student.studentLastName }}</span>
+              </div>
+              <div class="attendance-toggle">
+                @if (student.isPresent) {
+                  <ng-icon name="heroCheck" size="20" class="icon-present" />
+                  <span class="present-label">Present</span>
+                } @else {
+                  <ng-icon name="heroXMark" size="20" class="icon-absent" />
+                  <span class="absent-label">Absent</span>
+                }
+              </div>
+            </div>
+          }
+        </div>
+      }
+
+      <div class="modal-actions">
+        <button type="button" class="btn-cancel" (click)="closeAttendanceModal()">Close</button>
+      </div>
+    </div>
+  </div>
+}

--- a/src/TeacherSuite.Web/src/teacher-suite-ui/src/app/pages/lesson-plan/lesson-plan.html
+++ b/src/TeacherSuite.Web/src/teacher-suite-ui/src/app/pages/lesson-plan/lesson-plan.html
@@ -1,45 +1,53 @@
 <div class="lesson-plan-page">
-  <!-- Header area: title on left, mini calendar on right -->
+  <!-- Header area -->
   <div class="page-header">
     <div class="header-left">
       <div class="header-title">
         <ng-icon name="heroCalendarDays" size="28" />
         <h1>Lesson Plan</h1>
       </div>
-      <button class="btn-schedule" (click)="openScheduleModal()">
-        <ng-icon name="heroPlus" size="18" />
-        Schedule Lesson
-      </button>
+      <div class="header-actions">
+        <button class="btn-schedule" (click)="openScheduleModal()">
+          <ng-icon name="heroPlus" size="18" />
+          Schedule Lesson
+        </button>
+        <button class="btn-select-date" (click)="toggleCalendar()">
+          <ng-icon name="heroCalendarDays" size="18" />
+          {{ showCalendar ? 'Hide Calendar' : 'Select Date' }}
+        </button>
+      </div>
     </div>
 
-    <div class="mini-calendar">
-      <div class="calendar-nav">
-        <button class="cal-nav-btn" (click)="prevCalendarMonth()" aria-label="Previous month">
-          <ng-icon name="heroChevronLeft" size="14" />
-        </button>
-        <span class="cal-month-label">{{ calendarMonthLabel }}</span>
-        <button class="cal-nav-btn" (click)="nextCalendarMonth()" aria-label="Next month">
-          <ng-icon name="heroChevronRight" size="14" />
-        </button>
+    @if (showCalendar) {
+      <div class="mini-calendar">
+        <div class="calendar-nav">
+          <button class="cal-nav-btn" (click)="prevCalendarMonth()" aria-label="Previous month">
+            <ng-icon name="heroChevronLeft" size="14" />
+          </button>
+          <span class="cal-month-label">{{ calendarMonthLabel }}</span>
+          <button class="cal-nav-btn" (click)="nextCalendarMonth()" aria-label="Next month">
+            <ng-icon name="heroChevronRight" size="14" />
+          </button>
+        </div>
+        <div class="calendar-grid">
+          @for (label of weekDayLabels; track label) {
+            <div class="cal-weekday">{{ label }}</div>
+          }
+          @for (day of calendarDays; track day.date.getTime()) {
+            <div class="cal-day"
+                 [class.other-month]="!day.isCurrentMonth"
+                 [class.today]="day.isToday"
+                 [class.has-lesson]="day.hasLesson"
+                 (click)="onCalendarDayClick(day)">
+              <span class="cal-day-num">{{ day.day }}</span>
+              @if (day.hasLesson) {
+                <span class="cal-dot"></span>
+              }
+            </div>
+          }
+        </div>
       </div>
-      <div class="calendar-grid">
-        @for (label of weekDayLabels; track label) {
-          <div class="cal-weekday">{{ label }}</div>
-        }
-        @for (day of calendarDays; track $index) {
-          <div class="cal-day"
-               [class.other-month]="!day.isCurrentMonth"
-               [class.today]="day.isToday"
-               [class.has-lesson]="day.hasLesson"
-               (click)="onCalendarDayClick(day)">
-            <span class="cal-day-num">{{ day.day }}</span>
-            @if (day.hasLesson) {
-              <span class="cal-dot"></span>
-            }
-          </div>
-        }
-      </div>
-    </div>
+    }
   </div>
 
   <!-- Toolbar: period navigation + filters -->
@@ -141,7 +149,7 @@
               </tr>
             }
             @for (lesson of group.lessons; track lesson.id) {
-              <tr class="lesson-row">
+              <tr class="lesson-row" [class.warning-row]="isPastWithoutAttendance(lesson)">
                 <td class="col-status">
                   <span class="status-badge"
                         [class.active]="getLessonStatus(lesson) === 'active'"
@@ -149,6 +157,11 @@
                         [class.upcoming]="getLessonStatus(lesson) === 'upcoming'">
                     {{ getStatusLabel(lesson) }}
                   </span>
+                  @if (isPastWithoutAttendance(lesson)) {
+                    <span class="warning-badge" title="Attendance not recorded">
+                      <ng-icon name="heroExclamationTriangle" size="14" />
+                    </span>
+                  }
                 </td>
                 <td class="col-title">{{ lesson.lessonTitle }}</td>
                 <td class="col-course">{{ lesson.courseName }}</td>
@@ -255,10 +268,10 @@
           @for (student of studentAttendances; track student.studentId) {
             <div
               class="attendance-item"
-              [class.present]="student.isPresent"
+              [class.present]="isStudentPresent(student)"
               role="button"
               tabindex="0"
-              [attr.aria-pressed]="student.isPresent"
+              [attr.aria-pressed]="isStudentPresent(student)"
               (click)="toggleAttendance(student)"
               (keydown.enter)="toggleAttendance(student)"
               (keydown.space)="toggleAttendance(student); $event.preventDefault()">
@@ -266,7 +279,7 @@
                 <span class="student-name">{{ student.studentFirstName }} {{ student.studentLastName }}</span>
               </div>
               <div class="attendance-toggle">
-                @if (student.isPresent) {
+                @if (isStudentPresent(student)) {
                   <ng-icon name="heroCheck" size="20" class="icon-present" />
                   <span class="present-label">Present</span>
                 } @else {
@@ -280,7 +293,10 @@
       }
 
       <div class="modal-actions">
-        <button type="button" class="btn-cancel" (click)="closeAttendanceModal()">Close</button>
+        <button type="button" class="btn-cancel" (click)="closeAttendanceModal()">Cancel</button>
+        <button type="button" class="btn-submit" [disabled]="!attendanceDirty || savingAttendance" (click)="saveAttendance()">
+          {{ savingAttendance ? 'Saving...' : 'Save' }}
+        </button>
       </div>
     </div>
   </div>

--- a/src/TeacherSuite.Web/src/teacher-suite-ui/src/app/pages/lesson-plan/lesson-plan.html
+++ b/src/TeacherSuite.Web/src/teacher-suite-ui/src/app/pages/lesson-plan/lesson-plan.html
@@ -169,8 +169,15 @@
       @if (!loadingAttendance && studentAttendances.length > 0) {
         <div class="attendance-list">
           @for (student of studentAttendances; track student.studentId) {
-            <div class="attendance-item" [class.present]="student.isPresent"
-                 (click)="toggleAttendance(student)">
+            <div
+              class="attendance-item"
+              [class.present]="student.isPresent"
+              role="button"
+              tabindex="0"
+              [attr.aria-pressed]="student.isPresent"
+              (click)="toggleAttendance(student)"
+              (keydown.enter)="toggleAttendance(student)"
+              (keydown.space)="toggleAttendance(student); $event.preventDefault()">
               <div class="student-info">
                 <span class="student-name">{{ student.studentFirstName }} {{ student.studentLastName }}</span>
               </div>

--- a/src/TeacherSuite.Web/src/teacher-suite-ui/src/app/pages/lesson-plan/lesson-plan.html
+++ b/src/TeacherSuite.Web/src/teacher-suite-ui/src/app/pages/lesson-plan/lesson-plan.html
@@ -153,7 +153,7 @@
                 <td class="col-title">{{ lesson.lessonTitle }}</td>
                 <td class="col-course">{{ lesson.courseName }}</td>
                 <td class="col-group">{{ lesson.groupName }}</td>
-                <td class="col-date">{{ formatDateStart(lesson.scheduledStart) }}</td>
+                <td class="col-date">{{ formatScheduledDateTime(lesson.scheduledStart) }}</td>
                 <td class="col-actions">
                   <div class="action-buttons">
                     <button class="btn-action btn-details" (click)="navigateToLesson(lesson.lessonId)">

--- a/src/TeacherSuite.Web/src/teacher-suite-ui/src/app/pages/lesson-plan/lesson-plan.html
+++ b/src/TeacherSuite.Web/src/teacher-suite-ui/src/app/pages/lesson-plan/lesson-plan.html
@@ -1,14 +1,94 @@
 <div class="lesson-plan-page">
-  <!-- Header -->
+  <!-- Header area: title on left, mini calendar on right -->
   <div class="page-header">
-    <div class="header-content">
-      <ng-icon name="heroCalendarDays" size="32" />
-      <h1>Lesson Plan</h1>
+    <div class="header-left">
+      <div class="header-title">
+        <ng-icon name="heroCalendarDays" size="28" />
+        <h1>Lesson Plan</h1>
+      </div>
+      <button class="btn-schedule" (click)="openScheduleModal()">
+        <ng-icon name="heroPlus" size="18" />
+        Schedule Lesson
+      </button>
     </div>
-    <button class="btn-schedule" (click)="openScheduleModal()">
-      <ng-icon name="heroPlus" size="20" />
-      Schedule Lesson
-    </button>
+
+    <div class="mini-calendar">
+      <div class="calendar-nav">
+        <button class="cal-nav-btn" (click)="prevCalendarMonth()" aria-label="Previous month">
+          <ng-icon name="heroChevronLeft" size="14" />
+        </button>
+        <span class="cal-month-label">{{ calendarMonthLabel }}</span>
+        <button class="cal-nav-btn" (click)="nextCalendarMonth()" aria-label="Next month">
+          <ng-icon name="heroChevronRight" size="14" />
+        </button>
+      </div>
+      <div class="calendar-grid">
+        @for (label of weekDayLabels; track label) {
+          <div class="cal-weekday">{{ label }}</div>
+        }
+        @for (day of calendarDays; track $index) {
+          <div class="cal-day"
+               [class.other-month]="!day.isCurrentMonth"
+               [class.today]="day.isToday"
+               [class.has-lesson]="day.hasLesson"
+               (click)="onCalendarDayClick(day)">
+            <span class="cal-day-num">{{ day.day }}</span>
+            @if (day.hasLesson) {
+              <span class="cal-dot"></span>
+            }
+          </div>
+        }
+      </div>
+    </div>
+  </div>
+
+  <!-- Toolbar: period navigation + filters -->
+  <div class="toolbar">
+    <div class="period-nav">
+      <div class="view-toggle">
+        <button class="toggle-btn" [class.active]="viewMode === 'weekly'"
+                (click)="viewMode = 'weekly'; onViewModeChange()">Weekly</button>
+        <button class="toggle-btn" [class.active]="viewMode === 'monthly'"
+                (click)="viewMode = 'monthly'; onViewModeChange()">Monthly</button>
+      </div>
+      <button class="nav-arrow" (click)="prevPeriod()" aria-label="Previous period">
+        <ng-icon name="heroChevronLeft" size="18" />
+      </button>
+      <span class="period-label">{{ periodLabel }}</span>
+      <button class="nav-arrow" (click)="nextPeriod()" aria-label="Next period">
+        <ng-icon name="heroChevronRight" size="18" />
+      </button>
+      <button class="today-btn" (click)="goToToday()">Today</button>
+    </div>
+
+    <div class="filters">
+      <div class="filter-item">
+        <label for="groupBy">Group by</label>
+        <select id="groupBy" [(ngModel)]="groupByMode">
+          <option value="none">None</option>
+          <option value="course">Course</option>
+          <option value="group">Group</option>
+        </select>
+      </div>
+      <div class="filter-item">
+        <label for="filterCourse">Course</label>
+        <select id="filterCourse" [(ngModel)]="filterCourse">
+          <option value="">All Courses</option>
+          @for (c of availableCourses; track c) {
+            <option [value]="c">{{ c }}</option>
+          }
+        </select>
+      </div>
+      <div class="filter-item">
+        <label for="filterGroup">Group</label>
+        <select id="filterGroup" [(ngModel)]="filterGroup">
+          <option value="">All Groups</option>
+          @for (g of availableGroups; track g) {
+            <option [value]="g">{{ g }}</option>
+          }
+        </select>
+      </div>
+    </div>
   </div>
 
   <!-- Alerts -->
@@ -21,74 +101,76 @@
 
   <!-- Loading -->
   @if (loading) {
-    <div class="loading-grid">
-      @for (i of [1, 2, 3, 4]; track i) {
-        <div class="skeleton-card">
-          <div class="skeleton-line wide"></div>
-          <div class="skeleton-line medium"></div>
-          <div class="skeleton-line narrow"></div>
-        </div>
-      }
+    <div class="loading-state">
+      <div class="loading-spinner"></div>
+      <p>Loading lessons...</p>
     </div>
   }
 
-  <!-- Empty State -->
-  @if (!loading && scheduledLessons.length === 0) {
+  <!-- Empty state -->
+  @if (!loading && filteredLessons.length === 0) {
     <div class="empty-state">
-      <ng-icon name="heroCalendarDays" size="64" />
+      <ng-icon name="heroCalendarDays" size="56" />
       <h2>No scheduled lessons</h2>
-      <p>Schedule your first lesson to see it here.</p>
+      <p>No lessons found for this period.</p>
     </div>
   }
 
-  <!-- Lesson Plan Grid -->
-  @if (!loading && scheduledLessons.length > 0) {
-    <div class="lesson-plan-grid">
-      @for (lesson of scheduledLessons; track lesson.id) {
-        <div class="lesson-card" [class.status-active]="getLessonStatus(lesson) === 'active'"
-             [class.status-completed]="getLessonStatus(lesson) === 'completed'"
-             [class.status-upcoming]="getLessonStatus(lesson) === 'upcoming'">
-          <div class="card-header">
-            <span class="status-badge" [class.active]="getLessonStatus(lesson) === 'active'"
-                  [class.completed]="getLessonStatus(lesson) === 'completed'"
-                  [class.upcoming]="getLessonStatus(lesson) === 'upcoming'">
-              {{ getStatusLabel(lesson) }}
-            </span>
-            <span class="lesson-order">#{{ lesson.lessonOrder }}</span>
-          </div>
-
-          <h3 class="lesson-title">{{ lesson.lessonTitle }}</h3>
-
-          <div class="lesson-meta">
-            <div class="meta-item">
-              <ng-icon name="heroBookOpen" size="16" />
-              <span>{{ lesson.courseName }}</span>
-            </div>
-            <div class="meta-item">
-              <ng-icon name="heroUserGroup" size="16" />
-              <span>{{ lesson.groupName }}</span>
-            </div>
-            <div class="meta-item">
-              <ng-icon name="heroClock" size="16" />
-              <span>{{ formatDateTime(lesson.scheduledStart) }}</span>
-            </div>
-            <div class="meta-item time-range">
-              <span>{{ formatTime(lesson.scheduledStart) }} — {{ formatTime(lesson.scheduledEnd) }}</span>
-            </div>
-          </div>
-
-          <div class="card-actions">
-            <button class="btn-action btn-details" (click)="navigateToLesson(lesson.lessonId)">
-              <ng-icon name="heroEye" size="16" />
-              Details
-            </button>
-            <button class="btn-action btn-attendance" (click)="openAttendanceModal(lesson)">
-              <ng-icon name="heroUserGroup" size="16" />
-              Attendance
-            </button>
-          </div>
-        </div>
-      }
+  <!-- Lesson table -->
+  @if (!loading && filteredLessons.length > 0) {
+    <div class="table-container">
+      <table class="lesson-table">
+        <thead>
+          <tr>
+            <th class="col-status">Status</th>
+            <th class="col-title">Lesson Title</th>
+            <th class="col-course">Course</th>
+            <th class="col-group">Group</th>
+            <th class="col-date">Date &amp; Time</th>
+            <th class="col-actions">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          @for (group of groupedLessons; track group.label) {
+            @if (groupByMode !== 'none') {
+              <tr class="group-header-row">
+                <td colspan="6">
+                  <span class="group-label">{{ group.label }}</span>
+                  <span class="group-count">({{ group.lessons.length }})</span>
+                </td>
+              </tr>
+            }
+            @for (lesson of group.lessons; track lesson.id) {
+              <tr class="lesson-row">
+                <td class="col-status">
+                  <span class="status-badge"
+                        [class.active]="getLessonStatus(lesson) === 'active'"
+                        [class.completed]="getLessonStatus(lesson) === 'completed'"
+                        [class.upcoming]="getLessonStatus(lesson) === 'upcoming'">
+                    {{ getStatusLabel(lesson) }}
+                  </span>
+                </td>
+                <td class="col-title">{{ lesson.lessonTitle }}</td>
+                <td class="col-course">{{ lesson.courseName }}</td>
+                <td class="col-group">{{ lesson.groupName }}</td>
+                <td class="col-date">{{ formatDateStart(lesson.scheduledStart) }}</td>
+                <td class="col-actions">
+                  <div class="action-buttons">
+                    <button class="btn-action btn-details" (click)="navigateToLesson(lesson.lessonId)">
+                      <ng-icon name="heroEye" size="14" />
+                      Details
+                    </button>
+                    <button class="btn-action btn-attendance" (click)="openAttendanceModal(lesson)">
+                      <ng-icon name="heroUserGroup" size="14" />
+                      Attendance
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            }
+          }
+        </tbody>
+      </table>
     </div>
   }
 </div>
@@ -120,7 +202,7 @@
           <select id="lessonId" formControlName="lessonId" [disabled]="!lessons.length">
             <option value="">Select a lesson</option>
             @for (l of lessons; track l.id) {
-              <option [value]="l.id">#{{ l.order }} — {{ l.title }} ({{ l.durationMinutes }}min)</option>
+              <option [value]="l.id">#{{ l.order }} &mdash; {{ l.title }} ({{ l.durationMinutes }}min)</option>
             }
           </select>
         </div>
@@ -152,10 +234,12 @@
 <!-- Attendance Modal -->
 @if (showAttendanceModal && selectedScheduledLesson) {
   <div class="modal-overlay" (click)="closeAttendanceModal()">
-    <div class="modal-content attendance-modal" role="dialog" aria-modal="true" aria-labelledby="attendanceModalTitle" aria-describedby="attendanceModalSubtitle" (click)="$event.stopPropagation()">
+    <div class="modal-content attendance-modal" role="dialog" aria-modal="true"
+         aria-labelledby="attendanceModalTitle" aria-describedby="attendanceModalSubtitle"
+         (click)="$event.stopPropagation()">
       <h2 id="attendanceModalTitle">Student Attendance</h2>
       <p class="attendance-subtitle" id="attendanceModalSubtitle">
-        {{ selectedScheduledLesson.lessonTitle }} — {{ selectedScheduledLesson.groupName }}
+        {{ selectedScheduledLesson.lessonTitle }} &mdash; {{ selectedScheduledLesson.groupName }}
       </p>
 
       @if (loadingAttendance) {

--- a/src/TeacherSuite.Web/src/teacher-suite-ui/src/app/pages/lesson-plan/lesson-plan.html
+++ b/src/TeacherSuite.Web/src/teacher-suite-ui/src/app/pages/lesson-plan/lesson-plan.html
@@ -96,8 +96,13 @@
 <!-- Schedule Modal -->
 @if (showScheduleModal) {
   <div class="modal-overlay" (click)="closeScheduleModal()">
-    <div class="modal-content" (click)="$event.stopPropagation()">
-      <h2>Schedule a Lesson</h2>
+    <div
+      class="modal-content"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="schedule-modal-title"
+      (click)="$event.stopPropagation()">
+      <h2 id="schedule-modal-title">Schedule a Lesson</h2>
 
       <form [formGroup]="scheduleForm" (ngSubmit)="scheduleLesson()">
         <div class="form-group">

--- a/src/TeacherSuite.Web/src/teacher-suite-ui/src/app/pages/lesson-plan/lesson-plan.html
+++ b/src/TeacherSuite.Web/src/teacher-suite-ui/src/app/pages/lesson-plan/lesson-plan.html
@@ -152,9 +152,9 @@
 <!-- Attendance Modal -->
 @if (showAttendanceModal && selectedScheduledLesson) {
   <div class="modal-overlay" (click)="closeAttendanceModal()">
-    <div class="modal-content attendance-modal" (click)="$event.stopPropagation()">
-      <h2>Student Attendance</h2>
-      <p class="attendance-subtitle">
+    <div class="modal-content attendance-modal" role="dialog" aria-modal="true" aria-labelledby="attendanceModalTitle" aria-describedby="attendanceModalSubtitle" (click)="$event.stopPropagation()">
+      <h2 id="attendanceModalTitle">Student Attendance</h2>
+      <p class="attendance-subtitle" id="attendanceModalSubtitle">
         {{ selectedScheduledLesson.lessonTitle }} — {{ selectedScheduledLesson.groupName }}
       </p>
 

--- a/src/TeacherSuite.Web/src/teacher-suite-ui/src/app/pages/lesson-plan/lesson-plan.scss
+++ b/src/TeacherSuite.Web/src/teacher-suite-ui/src/app/pages/lesson-plan/lesson-plan.scss
@@ -1,0 +1,492 @@
+.lesson-plan-page {
+  padding: 2rem;
+  max-width: 1400px;
+  margin: 0 auto;
+}
+
+.page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 2rem;
+
+  .header-content {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  h1 {
+    font-size: 2rem;
+    color: #1a1a2e;
+    margin: 0;
+  }
+}
+
+.btn-schedule {
+  padding: 0.75rem 1.5rem;
+  border-radius: 8px;
+  font-size: 0.95rem;
+  font-weight: 500;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  transition: all 0.2s ease;
+  cursor: pointer;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: white;
+  border: none;
+
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(102, 126, 234, 0.4);
+  }
+}
+
+// Alerts
+.alert {
+  padding: 1rem 1.25rem;
+  border-radius: 8px;
+  margin-bottom: 1.5rem;
+  font-size: 0.95rem;
+}
+
+.alert-error {
+  background: #fef2f2;
+  color: #991b1b;
+  border: 1px solid #fecaca;
+}
+
+.alert-success {
+  background: #f0fdf4;
+  color: #166534;
+  border: 1px solid #bbf7d0;
+}
+
+// Loading
+.loading-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 1.5rem;
+}
+
+.skeleton-card {
+  background: #fff;
+  border-radius: 12px;
+  padding: 1.5rem;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+}
+
+.skeleton-line {
+  height: 16px;
+  border-radius: 4px;
+  background: linear-gradient(90deg, #f0f0f0 25%, #e0e0e0 50%, #f0f0f0 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.5s infinite;
+  margin-bottom: 0.75rem;
+
+  &.wide { width: 80%; }
+  &.medium { width: 60%; }
+  &.narrow { width: 40%; }
+}
+
+@keyframes shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+// Empty state
+.empty-state {
+  text-align: center;
+  padding: 4rem 2rem;
+  color: #9ca3af;
+
+  h2 {
+    margin-top: 1rem;
+    color: #6b7280;
+  }
+
+  p {
+    margin-top: 0.5rem;
+    color: #9ca3af;
+  }
+}
+
+// Lesson plan grid
+.lesson-plan-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 1.5rem;
+}
+
+.lesson-card {
+  background: #fff;
+  border-radius: 12px;
+  padding: 1.5rem;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+  border-left: 4px solid #d1d5db;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
+  }
+
+  &.status-active {
+    border-left-color: #22c55e;
+    background: linear-gradient(to right, rgba(34, 197, 94, 0.03), transparent);
+  }
+
+  &.status-completed {
+    border-left-color: #9ca3af;
+    opacity: 0.8;
+  }
+
+  &.status-upcoming {
+    border-left-color: #3b82f6;
+  }
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.75rem;
+  border-radius: 20px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+
+  &.active {
+    background: #dcfce7;
+    color: #166534;
+  }
+
+  &.completed {
+    background: #f3f4f6;
+    color: #6b7280;
+  }
+
+  &.upcoming {
+    background: #dbeafe;
+    color: #1e40af;
+  }
+}
+
+.lesson-order {
+  font-size: 0.85rem;
+  color: #9ca3af;
+  font-weight: 600;
+}
+
+.lesson-title {
+  font-size: 1.15rem;
+  color: #1a1a2e;
+  margin: 0 0 1rem;
+  font-weight: 600;
+}
+
+.lesson-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1.25rem;
+}
+
+.meta-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  color: #6b7280;
+
+  &.time-range {
+    font-weight: 500;
+    color: #374151;
+    padding-left: 1.5rem;
+  }
+}
+
+.card-actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.btn-action {
+  flex: 1;
+  padding: 0.5rem 0.75rem;
+  border-radius: 8px;
+  font-size: 0.85rem;
+  font-weight: 500;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.375rem;
+  transition: all 0.2s ease;
+  cursor: pointer;
+  border: none;
+}
+
+.btn-details {
+  background: #e0e7ff;
+  color: #667eea;
+
+  &:hover {
+    background: #c7d2fe;
+  }
+}
+
+.btn-attendance {
+  background: #fef3c7;
+  color: #92400e;
+
+  &:hover {
+    background: #fde68a;
+  }
+}
+
+// Modal
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  animation: fadeIn 0.2s ease;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.modal-content {
+  background: white;
+  border-radius: 16px;
+  padding: 2rem;
+  width: 90%;
+  max-width: 500px;
+  max-height: 85vh;
+  overflow-y: auto;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.15);
+  animation: slideUp 0.3s ease;
+
+  h2 {
+    margin: 0 0 1.5rem;
+    color: #1a1a2e;
+    font-size: 1.5rem;
+  }
+}
+
+@keyframes slideUp {
+  from { transform: translateY(20px); opacity: 0; }
+  to { transform: translateY(0); opacity: 1; }
+}
+
+.form-group {
+  margin-bottom: 1.25rem;
+
+  label {
+    display: block;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: #374151;
+    margin-bottom: 0.375rem;
+  }
+
+  select,
+  input[type="datetime-local"] {
+    width: 100%;
+    padding: 0.625rem 0.75rem;
+    border: 1px solid #d1d5db;
+    border-radius: 8px;
+    font-size: 0.95rem;
+    background: white;
+    transition: border-color 0.2s;
+
+    &:focus {
+      outline: none;
+      border-color: #667eea;
+      box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.15);
+    }
+
+    &:disabled {
+      background: #f9fafb;
+      color: #9ca3af;
+    }
+  }
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+}
+
+.btn-cancel {
+  padding: 0.625rem 1.25rem;
+  border-radius: 8px;
+  font-size: 0.95rem;
+  font-weight: 500;
+  cursor: pointer;
+  background: #f3f4f6;
+  color: #374151;
+  border: none;
+
+  &:hover {
+    background: #e5e7eb;
+  }
+}
+
+.btn-submit {
+  padding: 0.625rem 1.25rem;
+  border-radius: 8px;
+  font-size: 0.95rem;
+  font-weight: 500;
+  cursor: pointer;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: white;
+  border: none;
+
+  &:hover:not(:disabled) {
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(102, 126, 234, 0.4);
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}
+
+// Attendance modal
+.attendance-modal {
+  max-width: 550px;
+}
+
+.attendance-subtitle {
+  color: #6b7280;
+  font-size: 0.9rem;
+  margin: -0.5rem 0 1.5rem;
+}
+
+.loading-spinner {
+  width: 40px;
+  height: 40px;
+  border: 3px solid #e5e7eb;
+  border-top-color: #667eea;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+  margin: 2rem auto;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.no-students {
+  text-align: center;
+  color: #9ca3af;
+  padding: 2rem 0;
+}
+
+.attendance-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.attendance-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  background: #f9fafb;
+  cursor: pointer;
+  transition: background 0.2s;
+
+  &:hover {
+    background: #f3f4f6;
+  }
+
+  &.present {
+    background: #f0fdf4;
+
+    &:hover {
+      background: #dcfce7;
+    }
+  }
+}
+
+.student-info {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.student-name {
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: #1a1a2e;
+}
+
+.attendance-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+}
+
+.icon-present {
+  color: #22c55e;
+}
+
+.icon-absent {
+  color: #ef4444;
+}
+
+.present-label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #166534;
+}
+
+.absent-label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #991b1b;
+}
+
+// Responsive
+@media (max-width: 768px) {
+  .lesson-plan-page {
+    padding: 1rem;
+  }
+
+  .page-header {
+    flex-direction: column;
+    gap: 1rem;
+    align-items: flex-start;
+  }
+
+  .lesson-plan-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .card-actions {
+    flex-direction: column;
+  }
+}

--- a/src/TeacherSuite.Web/src/teacher-suite-ui/src/app/pages/lesson-plan/lesson-plan.scss
+++ b/src/TeacherSuite.Web/src/teacher-suite-ui/src/app/pages/lesson-plan/lesson-plan.scss
@@ -20,6 +20,31 @@
   gap: 1rem;
 }
 
+.header-actions {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.btn-select-date {
+  padding: 0.6rem 1.25rem;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  font-weight: 500;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  background: white;
+  color: #667eea;
+  border: 1px solid #667eea;
+  transition: all 0.2s ease;
+
+  &:hover {
+    background: #eef2ff;
+  }
+}
+
 .header-title {
   display: flex;
   align-items: center;
@@ -462,6 +487,22 @@
     background: #dbeafe;
     color: #1e40af;
   }
+}
+
+.warning-row {
+  background: #fef2f2 !important;
+
+  &:hover {
+    background: #fee2e2 !important;
+  }
+}
+
+.warning-badge {
+  display: inline-flex;
+  align-items: center;
+  color: #dc2626;
+  margin-left: 0.35rem;
+  vertical-align: middle;
 }
 
 // ---- Action buttons ----

--- a/src/TeacherSuite.Web/src/teacher-suite-ui/src/app/pages/lesson-plan/lesson-plan.scss
+++ b/src/TeacherSuite.Web/src/teacher-suite-ui/src/app/pages/lesson-plan/lesson-plan.scss
@@ -4,51 +4,289 @@
   margin: 0 auto;
 }
 
+// ---- Header ----
+
 .page-header {
   display: flex;
   justify-content: space-between;
-  align-items: center;
-  margin-bottom: 2rem;
+  align-items: flex-start;
+  margin-bottom: 1.5rem;
+  gap: 2rem;
+}
 
-  .header-content {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-  }
+.header-left {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.header-title {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
 
   h1 {
-    font-size: 2rem;
+    font-size: 1.75rem;
     color: #1a1a2e;
     margin: 0;
   }
 }
 
 .btn-schedule {
-  padding: 0.75rem 1.5rem;
+  padding: 0.6rem 1.25rem;
   border-radius: 8px;
-  font-size: 0.95rem;
+  font-size: 0.9rem;
   font-weight: 500;
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
-  transition: all 0.2s ease;
   cursor: pointer;
   background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
   color: white;
   border: none;
+  transition: all 0.2s ease;
+  align-self: flex-start;
 
   &:hover {
-    transform: translateY(-2px);
+    transform: translateY(-1px);
     box-shadow: 0 4px 12px rgba(102, 126, 234, 0.4);
   }
 }
 
-// Alerts
-.alert {
-  padding: 1rem 1.25rem;
-  border-radius: 8px;
+// ---- Mini Calendar ----
+
+.mini-calendar {
+  width: 250px;
+  flex-shrink: 0;
+  background: white;
+  border-radius: 10px;
+  padding: 0.75rem;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  border: 1px solid #e5e7eb;
+}
+
+.calendar-nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.cal-nav-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0.25rem;
+  border-radius: 4px;
+  color: #6b7280;
+  display: inline-flex;
+  align-items: center;
+
+  &:hover {
+    background: #f3f4f6;
+    color: #1a1a2e;
+  }
+}
+
+.cal-month-label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #1a1a2e;
+}
+
+.calendar-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 1px;
+  text-align: center;
+}
+
+.cal-weekday {
+  font-size: 0.65rem;
+  font-weight: 600;
+  color: #9ca3af;
+  padding: 0.15rem 0;
+  text-transform: uppercase;
+}
+
+.cal-day {
+  position: relative;
+  padding: 0.2rem 0;
+  cursor: pointer;
+  border-radius: 4px;
+  transition: background 0.15s;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-height: 28px;
+  justify-content: center;
+
+  &:hover {
+    background: #eef2ff;
+  }
+
+  &.other-month {
+    opacity: 0.3;
+  }
+
+  &.today .cal-day-num {
+    background: #667eea;
+    color: white;
+    border-radius: 50%;
+    width: 22px;
+    height: 22px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+}
+
+.cal-day-num {
+  font-size: 0.7rem;
+  color: #374151;
+  line-height: 1;
+}
+
+.cal-dot {
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: #667eea;
+  position: absolute;
+  bottom: 2px;
+}
+
+// ---- Toolbar ----
+
+.toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  flex-wrap: wrap;
+  gap: 1rem;
   margin-bottom: 1.5rem;
+  padding: 1rem;
+  background: white;
+  border-radius: 10px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+}
+
+.period-nav {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.view-toggle {
+  display: inline-flex;
+  border-radius: 6px;
+  overflow: hidden;
+  border: 1px solid #d1d5db;
+  margin-right: 0.5rem;
+}
+
+.toggle-btn {
+  padding: 0.4rem 0.85rem;
+  font-size: 0.8rem;
+  font-weight: 500;
+  border: none;
+  cursor: pointer;
+  background: white;
+  color: #6b7280;
+  transition: all 0.15s;
+
+  &.active {
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: white;
+  }
+
+  &:not(.active):hover {
+    background: #f3f4f6;
+  }
+}
+
+.nav-arrow {
+  background: none;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  cursor: pointer;
+  padding: 0.35rem;
+  display: inline-flex;
+  align-items: center;
+  color: #6b7280;
+
+  &:hover {
+    background: #f3f4f6;
+    color: #1a1a2e;
+  }
+}
+
+.period-label {
   font-size: 0.95rem;
+  font-weight: 600;
+  color: #1a1a2e;
+  min-width: 180px;
+  text-align: center;
+}
+
+.today-btn {
+  padding: 0.35rem 0.85rem;
+  font-size: 0.8rem;
+  font-weight: 500;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  cursor: pointer;
+  background: white;
+  color: #667eea;
+
+  &:hover {
+    background: #eef2ff;
+  }
+}
+
+.filters {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-end;
+}
+
+.filter-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+
+  label {
+    font-size: 0.7rem;
+    font-weight: 600;
+    color: #9ca3af;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+  }
+
+  select {
+    padding: 0.4rem 0.6rem;
+    border: 1px solid #d1d5db;
+    border-radius: 6px;
+    font-size: 0.82rem;
+    background: white;
+    color: #374151;
+    min-width: 120px;
+
+    &:focus {
+      outline: none;
+      border-color: #667eea;
+      box-shadow: 0 0 0 2px rgba(102, 126, 234, 0.15);
+    }
+  }
+}
+
+// ---- Alerts ----
+
+.alert {
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  margin-bottom: 1rem;
+  font-size: 0.9rem;
 }
 
 .alert-error {
@@ -63,106 +301,152 @@
   border: 1px solid #bbf7d0;
 }
 
-// Loading
-.loading-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
-  gap: 1.5rem;
+// ---- Loading ----
+
+.loading-state {
+  text-align: center;
+  padding: 3rem 1rem;
+  color: #9ca3af;
+
+  p {
+    margin-top: 0.75rem;
+    font-size: 0.9rem;
+  }
 }
 
-.skeleton-card {
-  background: #fff;
-  border-radius: 12px;
-  padding: 1.5rem;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+.loading-spinner {
+  width: 36px;
+  height: 36px;
+  border: 3px solid #e5e7eb;
+  border-top-color: #667eea;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+  margin: 0 auto;
 }
 
-.skeleton-line {
-  height: 16px;
-  border-radius: 4px;
-  background: linear-gradient(90deg, #f0f0f0 25%, #e0e0e0 50%, #f0f0f0 75%);
-  background-size: 200% 100%;
-  animation: shimmer 1.5s infinite;
-  margin-bottom: 0.75rem;
-
-  &.wide { width: 80%; }
-  &.medium { width: 60%; }
-  &.narrow { width: 40%; }
+@keyframes spin {
+  to { transform: rotate(360deg); }
 }
 
-@keyframes shimmer {
-  0% { background-position: 200% 0; }
-  100% { background-position: -200% 0; }
-}
+// ---- Empty state ----
 
-// Empty state
 .empty-state {
   text-align: center;
-  padding: 4rem 2rem;
+  padding: 3rem 2rem;
   color: #9ca3af;
 
   h2 {
-    margin-top: 1rem;
+    margin-top: 0.75rem;
     color: #6b7280;
+    font-size: 1.15rem;
   }
 
   p {
-    margin-top: 0.5rem;
+    margin-top: 0.35rem;
     color: #9ca3af;
+    font-size: 0.9rem;
   }
 }
 
-// Lesson plan grid
-.lesson-plan-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
-  gap: 1.5rem;
-}
+// ---- Table ----
 
-.lesson-card {
-  background: #fff;
-  border-radius: 12px;
-  padding: 1.5rem;
+.table-container {
+  background: white;
+  border-radius: 10px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
-  border-left: 4px solid #d1d5db;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  overflow: hidden;
+}
 
-  &:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
+.lesson-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.88rem;
+
+  thead {
+    background: #f8f9fb;
+    border-bottom: 2px solid #e5e7eb;
+
+    th {
+      padding: 0.7rem 0.85rem;
+      text-align: left;
+      font-weight: 600;
+      color: #6b7280;
+      font-size: 0.78rem;
+      text-transform: uppercase;
+      letter-spacing: 0.03em;
+      white-space: nowrap;
+    }
   }
 
-  &.status-active {
-    border-left-color: #22c55e;
-    background: linear-gradient(to right, rgba(34, 197, 94, 0.03), transparent);
+  tbody tr {
+    border-bottom: 1px solid #f0f0f0;
+    transition: background 0.15s;
+
+    &.lesson-row:hover {
+      background: #fafbff;
+    }
   }
 
-  &.status-completed {
-    border-left-color: #9ca3af;
-    opacity: 0.8;
-  }
-
-  &.status-upcoming {
-    border-left-color: #3b82f6;
+  td {
+    padding: 0.65rem 0.85rem;
+    color: #374151;
+    vertical-align: middle;
   }
 }
 
-.card-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 0.75rem;
+.col-status {
+  width: 110px;
 }
+
+.col-title {
+  font-weight: 500;
+  color: #1a1a2e !important;
+}
+
+.col-course,
+.col-group {
+  color: #6b7280;
+}
+
+.col-date {
+  white-space: nowrap;
+  color: #374151;
+  font-variant-numeric: tabular-nums;
+}
+
+.col-actions {
+  width: 220px;
+}
+
+.group-header-row td {
+  background: #f3f4f6;
+  padding: 0.5rem 0.85rem;
+  font-weight: 600;
+}
+
+.group-label {
+  color: #1a1a2e;
+  font-size: 0.9rem;
+}
+
+.group-count {
+  color: #9ca3af;
+  font-size: 0.8rem;
+  margin-left: 0.4rem;
+}
+
+// ---- Status badge ----
 
 .status-badge {
   display: inline-flex;
   align-items: center;
-  padding: 0.25rem 0.75rem;
+  padding: 0.2rem 0.6rem;
   border-radius: 20px;
-  font-size: 0.75rem;
+  font-size: 0.72rem;
   font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
 
   &.active {
     background: #dcfce7;
@@ -180,58 +464,25 @@
   }
 }
 
-.lesson-order {
-  font-size: 0.85rem;
-  color: #9ca3af;
-  font-weight: 600;
-}
+// ---- Action buttons ----
 
-.lesson-title {
-  font-size: 1.15rem;
-  color: #1a1a2e;
-  margin: 0 0 1rem;
-  font-weight: 600;
-}
-
-.lesson-meta {
+.action-buttons {
   display: flex;
-  flex-direction: column;
   gap: 0.5rem;
-  margin-bottom: 1.25rem;
-}
-
-.meta-item {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  font-size: 0.85rem;
-  color: #6b7280;
-
-  &.time-range {
-    font-weight: 500;
-    color: #374151;
-    padding-left: 1.5rem;
-  }
-}
-
-.card-actions {
-  display: flex;
-  gap: 0.75rem;
 }
 
 .btn-action {
-  flex: 1;
-  padding: 0.5rem 0.75rem;
-  border-radius: 8px;
-  font-size: 0.85rem;
+  padding: 0.35rem 0.65rem;
+  border-radius: 6px;
+  font-size: 0.78rem;
   font-weight: 500;
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  gap: 0.375rem;
-  transition: all 0.2s ease;
+  gap: 0.3rem;
   cursor: pointer;
   border: none;
+  transition: all 0.15s;
+  white-space: nowrap;
 }
 
 .btn-details {
@@ -252,7 +503,8 @@
   }
 }
 
-// Modal
+// ---- Modal ----
+
 .modal-overlay {
   position: fixed;
   top: 0;
@@ -372,7 +624,8 @@
   }
 }
 
-// Attendance modal
+// ---- Attendance modal ----
+
 .attendance-modal {
   max-width: 550px;
 }
@@ -381,20 +634,6 @@
   color: #6b7280;
   font-size: 0.9rem;
   margin: -0.5rem 0 1.5rem;
-}
-
-.loading-spinner {
-  width: 40px;
-  height: 40px;
-  border: 3px solid #e5e7eb;
-  border-top-color: #667eea;
-  border-radius: 50%;
-  animation: spin 0.8s linear infinite;
-  margin: 2rem auto;
-}
-
-@keyframes spin {
-  to { transform: rotate(360deg); }
 }
 
 .no-students {
@@ -470,23 +709,47 @@
   color: #991b1b;
 }
 
-// Responsive
+// ---- Responsive ----
+
+@media (max-width: 1024px) {
+  .page-header {
+    flex-direction: column;
+  }
+
+  .mini-calendar {
+    width: 100%;
+    max-width: 300px;
+  }
+
+  .toolbar {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .filters {
+    flex-wrap: wrap;
+  }
+}
+
 @media (max-width: 768px) {
   .lesson-plan-page {
     padding: 1rem;
   }
 
-  .page-header {
-    flex-direction: column;
-    gap: 1rem;
-    align-items: flex-start;
+  .table-container {
+    overflow-x: auto;
   }
 
-  .lesson-plan-grid {
-    grid-template-columns: 1fr;
+  .lesson-table {
+    min-width: 700px;
   }
 
-  .card-actions {
+  .period-nav {
+    flex-wrap: wrap;
+  }
+
+  .action-buttons {
     flex-direction: column;
+    gap: 0.25rem;
   }
 }

--- a/src/TeacherSuite.Web/src/teacher-suite-ui/src/app/pages/lesson-plan/lesson-plan.ts
+++ b/src/TeacherSuite.Web/src/teacher-suite-ui/src/app/pages/lesson-plan/lesson-plan.ts
@@ -6,7 +6,7 @@ import { Router } from '@angular/router';
 import { LessonPlanService, ScheduledLesson, StudentAttendance } from '../../services/lesson-plan.service';
 import { LessonService, Lesson } from '../../services/lesson.service';
 import { CourseService, Course } from '../../services/course.service';
-import { GroupService, Group } from '../../services/group.service';
+import { GroupService } from '../../services/group.service';
 import { KeycloakService } from '../../auth/keycloak.service';
 import { NgIconComponent, provideIcons } from '@ng-icons/core';
 import {
@@ -292,7 +292,6 @@ export class LessonPlanPage implements OnInit {
       day: 'numeric',
       hour: '2-digit',
       minute: '2-digit',
-      timeZone: 'UTC',
     });
   }
 
@@ -303,7 +302,6 @@ export class LessonPlanPage implements OnInit {
     return date.toLocaleTimeString('en-US', {
       hour: '2-digit',
       minute: '2-digit',
-      timeZone: 'UTC',
     });
   }
 }

--- a/src/TeacherSuite.Web/src/teacher-suite-ui/src/app/pages/lesson-plan/lesson-plan.ts
+++ b/src/TeacherSuite.Web/src/teacher-suite-ui/src/app/pages/lesson-plan/lesson-plan.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, ChangeDetectorRef, DestroyRef, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
-import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { FormBuilder, FormGroup, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { LessonPlanService, ScheduledLesson, StudentAttendance } from '../../services/lesson-plan.service';
 import { LessonService, Lesson } from '../../services/lesson.service';
@@ -19,11 +19,25 @@ import {
   heroCheck,
   heroXMark,
   heroChevronRight,
+  heroChevronLeft,
 } from '@ng-icons/heroicons/outline';
+
+export interface CalendarDay {
+  date: Date;
+  day: number;
+  isCurrentMonth: boolean;
+  isToday: boolean;
+  hasLesson: boolean;
+}
+
+export interface LessonGroup {
+  label: string;
+  lessons: ScheduledLesson[];
+}
 
 @Component({
   selector: 'app-lesson-plan',
-  imports: [CommonModule, ReactiveFormsModule, NgIconComponent],
+  imports: [CommonModule, FormsModule, ReactiveFormsModule, NgIconComponent],
   providers: [
     provideIcons({
       heroCalendarDays,
@@ -35,6 +49,7 @@ import {
       heroCheck,
       heroXMark,
       heroChevronRight,
+      heroChevronLeft,
     }),
   ],
   templateUrl: './lesson-plan.html',
@@ -47,6 +62,24 @@ export class LessonPlanPage implements OnInit {
   loading = true;
   error = '';
   success = '';
+
+  // View mode & period
+  viewMode: 'weekly' | 'monthly' = 'weekly';
+  currentDate = new Date();
+
+  // Mini calendar state
+  calendarYear = new Date().getFullYear();
+  calendarMonth = new Date().getMonth();
+  calendarDays: CalendarDay[] = [];
+  lessonDateStrings = new Set<string>();
+  readonly weekDayLabels = ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'];
+
+  // Filters
+  groupByMode: 'none' | 'course' | 'group' = 'none';
+  filterCourse = '';
+  filterGroup = '';
+  availableCourses: string[] = [];
+  availableGroups: string[] = [];
 
   // Schedule modal
   showScheduleModal = false;
@@ -87,18 +120,103 @@ export class LessonPlanPage implements OnInit {
   }
 
   ngOnInit(): void {
-    this.loadLessonPlan();
+    this.buildCalendar();
+    this.loadPeriodLessons();
   }
 
-  loadLessonPlan(): void {
+  // --- Period calculation ---
+
+  get periodStart(): Date {
+    if (this.viewMode === 'weekly') {
+      return this.getMonday(this.currentDate);
+    }
+    const d = new Date(this.currentDate);
+    return new Date(d.getFullYear(), d.getMonth(), 1);
+  }
+
+  get periodEnd(): Date {
+    if (this.viewMode === 'weekly') {
+      const monday = this.getMonday(this.currentDate);
+      const sunday = new Date(monday);
+      sunday.setDate(monday.getDate() + 6);
+      sunday.setHours(23, 59, 59, 999);
+      return sunday;
+    }
+    const d = new Date(this.currentDate);
+    return new Date(d.getFullYear(), d.getMonth() + 1, 0, 23, 59, 59, 999);
+  }
+
+  get periodLabel(): string {
+    if (this.viewMode === 'weekly') {
+      const start = this.periodStart;
+      const end = this.periodEnd;
+      const startStr = start.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+      const endStr = end.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+      return startStr + ' \u2013 ' + endStr;
+    }
+    return this.currentDate.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
+  }
+
+  private getMonday(d: Date): Date {
+    const date = new Date(d);
+    const day = date.getDay();
+    const diff = day === 0 ? -6 : 1 - day;
+    date.setDate(date.getDate() + diff);
+    date.setHours(0, 0, 0, 0);
+    return date;
+  }
+
+  // --- Period navigation ---
+
+  prevPeriod(): void {
+    if (this.viewMode === 'weekly') {
+      const d = new Date(this.currentDate);
+      d.setDate(d.getDate() - 7);
+      this.currentDate = d;
+    } else {
+      this.currentDate = new Date(this.currentDate.getFullYear(), this.currentDate.getMonth() - 1, 1);
+    }
+    this.loadPeriodLessons();
+  }
+
+  nextPeriod(): void {
+    if (this.viewMode === 'weekly') {
+      const d = new Date(this.currentDate);
+      d.setDate(d.getDate() + 7);
+      this.currentDate = d;
+    } else {
+      this.currentDate = new Date(this.currentDate.getFullYear(), this.currentDate.getMonth() + 1, 1);
+    }
+    this.loadPeriodLessons();
+  }
+
+  onViewModeChange(): void {
+    this.loadPeriodLessons();
+  }
+
+  goToToday(): void {
+    this.currentDate = new Date();
+    this.calendarYear = this.currentDate.getFullYear();
+    this.calendarMonth = this.currentDate.getMonth();
+    this.buildCalendar();
+    this.loadPeriodLessons();
+  }
+
+  // --- Data loading ---
+
+  loadPeriodLessons(): void {
     this.loading = true;
     this.error = '';
 
-    this.lessonPlanService.getLessonPlan()
+    const from = this.periodStart.toISOString();
+    const to = this.periodEnd.toISOString();
+
+    this.lessonPlanService.getLessonPlan(from, to)
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (data) => {
           this.scheduledLessons = data;
+          this.updateDerivedData();
           this.loading = false;
           this.cdr.detectChanges();
         },
@@ -109,6 +227,127 @@ export class LessonPlanPage implements OnInit {
         },
       });
   }
+
+  private updateDerivedData(): void {
+    const courseSet = new Set<string>();
+    const groupSet = new Set<string>();
+    this.lessonDateStrings.clear();
+
+    for (const lesson of this.scheduledLessons) {
+      courseSet.add(lesson.courseName);
+      groupSet.add(lesson.groupName);
+      const d = new Date(lesson.scheduledStart);
+      const dateStr = d.getFullYear() + '-' +
+        String(d.getMonth() + 1).padStart(2, '0') + '-' +
+        String(d.getDate()).padStart(2, '0');
+      this.lessonDateStrings.add(dateStr);
+    }
+
+    this.availableCourses = Array.from(courseSet).sort();
+    this.availableGroups = Array.from(groupSet).sort();
+    this.buildCalendar();
+  }
+
+  // --- Filtering & Grouping ---
+
+  get filteredLessons(): ScheduledLesson[] {
+    let result = this.scheduledLessons;
+    if (this.filterCourse) {
+      result = result.filter(l => l.courseName === this.filterCourse);
+    }
+    if (this.filterGroup) {
+      result = result.filter(l => l.groupName === this.filterGroup);
+    }
+    return result.sort((a, b) =>
+      new Date(a.scheduledStart).getTime() - new Date(b.scheduledStart).getTime()
+    );
+  }
+
+  get groupedLessons(): LessonGroup[] {
+    const lessons = this.filteredLessons;
+    if (this.groupByMode === 'none') {
+      return [{ label: '', lessons }];
+    }
+
+    const map = new Map<string, ScheduledLesson[]>();
+    for (const l of lessons) {
+      const key = this.groupByMode === 'course' ? l.courseName : l.groupName;
+      if (!map.has(key)) map.set(key, []);
+      map.get(key)!.push(l);
+    }
+
+    return Array.from(map.entries())
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([label, items]) => ({ label, lessons: items }));
+  }
+
+  // --- Mini calendar ---
+
+  buildCalendar(): void {
+    const year = this.calendarYear;
+    const month = this.calendarMonth;
+    const firstOfMonth = new Date(year, month, 1);
+    const dow = firstOfMonth.getDay();
+    const offset = dow === 0 ? -6 : 1 - dow;
+    const startDay = new Date(year, month, 1 + offset);
+
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    this.calendarDays = [];
+    const current = new Date(startDay);
+
+    for (let i = 0; i < 42; i++) {
+      const d = new Date(current);
+      d.setHours(0, 0, 0, 0);
+      const dateStr = d.getFullYear() + '-' +
+        String(d.getMonth() + 1).padStart(2, '0') + '-' +
+        String(d.getDate()).padStart(2, '0');
+
+      this.calendarDays.push({
+        date: new Date(d),
+        day: d.getDate(),
+        isCurrentMonth: d.getMonth() === month,
+        isToday: d.getTime() === today.getTime(),
+        hasLesson: this.lessonDateStrings.has(dateStr),
+      });
+      current.setDate(current.getDate() + 1);
+    }
+  }
+
+  prevCalendarMonth(): void {
+    if (this.calendarMonth === 0) {
+      this.calendarMonth = 11;
+      this.calendarYear--;
+    } else {
+      this.calendarMonth--;
+    }
+    this.buildCalendar();
+  }
+
+  nextCalendarMonth(): void {
+    if (this.calendarMonth === 11) {
+      this.calendarMonth = 0;
+      this.calendarYear++;
+    } else {
+      this.calendarMonth++;
+    }
+    this.buildCalendar();
+  }
+
+  get calendarMonthLabel(): string {
+    return new Date(this.calendarYear, this.calendarMonth, 1)
+      .toLocaleDateString('en-US', { month: 'short', year: 'numeric' });
+  }
+
+  onCalendarDayClick(day: CalendarDay): void {
+    this.currentDate = new Date(day.date);
+    this.calendarYear = day.date.getFullYear();
+    this.calendarMonth = day.date.getMonth();
+    this.loadPeriodLessons();
+  }
+
+  // --- Status helpers ---
 
   getLessonStatus(lesson: ScheduledLesson): 'upcoming' | 'active' | 'completed' {
     const now = new Date();
@@ -129,11 +368,30 @@ export class LessonPlanPage implements OnInit {
     }
   }
 
-  navigateToLesson(lessonId: number): void {
-    this.router.navigate(['/lessons', lessonId]);
+  // --- Format ---
+
+  formatDateStart(dateString: string): string {
+    if (!dateString) return 'N/A';
+    const date = new Date(dateString);
+    if (isNaN(date.getTime())) return 'Invalid Date';
+    const datePart = date.toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    });
+    const hours = String(date.getHours()).padStart(2, '0');
+    const minutes = String(date.getMinutes()).padStart(2, '0');
+    return datePart + ' ' + hours + ':' + minutes;
   }
 
-  // Schedule modal
+  // --- Navigation ---
+
+  navigateToLesson(lessonId: number): void {
+    this.router.navigate(['/lessons', lessonId], { queryParams: { from: 'lesson-plan' } });
+  }
+
+  // --- Schedule modal ---
+
   openScheduleModal(): void {
     this.showScheduleModal = true;
     this.scheduleForm.reset();
@@ -220,7 +478,7 @@ export class LessonPlanPage implements OnInit {
         next: () => {
           this.success = 'Lesson scheduled successfully';
           this.closeScheduleModal();
-          this.loadLessonPlan();
+          this.loadPeriodLessons();
           setTimeout(() => { this.success = ''; this.cdr.detectChanges(); }, 3000);
         },
         error: (err) => {
@@ -231,7 +489,8 @@ export class LessonPlanPage implements OnInit {
       });
   }
 
-  // Attendance modal
+  // --- Attendance modal ---
+
   openAttendanceModal(lesson: ScheduledLesson): void {
     this.selectedScheduledLesson = lesson;
     this.showAttendanceModal = true;
@@ -280,28 +539,5 @@ export class LessonPlanPage implements OnInit {
           setTimeout(() => { this.error = ''; this.cdr.detectChanges(); }, 5000);
         },
       });
-  }
-
-  formatDateTime(dateString: string): string {
-    if (!dateString) return 'N/A';
-    const date = new Date(dateString);
-    if (isNaN(date.getTime())) return 'Invalid Date';
-    return date.toLocaleDateString('en-US', {
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit',
-    });
-  }
-
-  formatTime(dateString: string): string {
-    if (!dateString) return 'N/A';
-    const date = new Date(dateString);
-    if (isNaN(date.getTime())) return 'Invalid';
-    return date.toLocaleTimeString('en-US', {
-      hour: '2-digit',
-      minute: '2-digit',
-    });
   }
 }

--- a/src/TeacherSuite.Web/src/teacher-suite-ui/src/app/pages/lesson-plan/lesson-plan.ts
+++ b/src/TeacherSuite.Web/src/teacher-suite-ui/src/app/pages/lesson-plan/lesson-plan.ts
@@ -267,6 +267,7 @@ export class LessonPlanPage implements OnInit {
           this.cdr.detectChanges();
         },
         error: () => {
+          this.calendarLessonDates.clear();
           this.buildCalendar();
           this.cdr.detectChanges();
         },
@@ -387,6 +388,8 @@ export class LessonPlanPage implements OnInit {
 
   onCalendarDayClick(day: CalendarDay): void {
     this.currentDate = new Date(day.date);
+    this.calendarYear = day.date.getFullYear();
+    this.calendarMonth = day.date.getMonth();
     this.showCalendar = false;
     this.loadPeriodLessons();
   }

--- a/src/TeacherSuite.Web/src/teacher-suite-ui/src/app/pages/lesson-plan/lesson-plan.ts
+++ b/src/TeacherSuite.Web/src/teacher-suite-ui/src/app/pages/lesson-plan/lesson-plan.ts
@@ -20,6 +20,7 @@ import {
   heroXMark,
   heroChevronRight,
   heroChevronLeft,
+  heroExclamationTriangle,
 } from '@ng-icons/heroicons/outline';
 
 export interface CalendarDay {
@@ -50,6 +51,7 @@ export interface LessonGroup {
       heroXMark,
       heroChevronRight,
       heroChevronLeft,
+      heroExclamationTriangle,
     }),
   ],
   templateUrl: './lesson-plan.html',
@@ -68,10 +70,11 @@ export class LessonPlanPage implements OnInit {
   currentDate = new Date();
 
   // Mini calendar state
+  showCalendar = false;
   calendarYear = new Date().getFullYear();
   calendarMonth = new Date().getMonth();
   calendarDays: CalendarDay[] = [];
-  lessonDateStrings = new Set<string>();
+  calendarLessonDates = new Set<string>();
   readonly weekDayLabels = ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'];
 
   // Filters
@@ -95,7 +98,10 @@ export class LessonPlanPage implements OnInit {
   showAttendanceModal = false;
   selectedScheduledLesson: ScheduledLesson | null = null;
   studentAttendances: StudentAttendance[] = [];
+  localAttendanceState: Map<string, boolean> = new Map();
   loadingAttendance = false;
+  savingAttendance = false;
+  attendanceDirty = false;
 
   isAdminOrSupervisor = false;
 
@@ -120,7 +126,6 @@ export class LessonPlanPage implements OnInit {
   }
 
   ngOnInit(): void {
-    this.buildCalendar();
     this.loadPeriodLessons();
   }
 
@@ -198,8 +203,10 @@ export class LessonPlanPage implements OnInit {
     this.currentDate = new Date();
     this.calendarYear = this.currentDate.getFullYear();
     this.calendarMonth = this.currentDate.getMonth();
-    this.buildCalendar();
     this.loadPeriodLessons();
+    if (this.showCalendar) {
+      this.loadCalendarDots();
+    }
   }
 
   // --- Data loading ---
@@ -216,7 +223,7 @@ export class LessonPlanPage implements OnInit {
       .subscribe({
         next: (data) => {
           this.scheduledLessons = data;
-          this.updateDerivedData();
+          this.updateFilters();
           this.loading = false;
           this.cdr.detectChanges();
         },
@@ -228,21 +235,57 @@ export class LessonPlanPage implements OnInit {
       });
   }
 
-  private updateDerivedData(): void {
+  private updateFilters(): void {
     const courseSet = new Set<string>();
     const groupSet = new Set<string>();
-    this.lessonDateStrings.clear();
 
     for (const lesson of this.scheduledLessons) {
       courseSet.add(lesson.courseName);
       groupSet.add(lesson.groupName);
-      const d = new Date(lesson.scheduledStart);
-      this.lessonDateStrings.add(this.toDateKey(d));
     }
 
     this.availableCourses = Array.from(courseSet).sort();
     this.availableGroups = Array.from(groupSet).sort();
-    this.buildCalendar();
+  }
+
+  // --- Calendar dots: separate data load for the displayed calendar month ---
+
+  loadCalendarDots(): void {
+    const calStart = this.getCalendarRangeStart();
+    const calEnd = this.getCalendarRangeEnd();
+
+    this.lessonPlanService.getLessonPlan(calStart.toISOString(), calEnd.toISOString())
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (data) => {
+          this.calendarLessonDates.clear();
+          for (const lesson of data) {
+            const d = new Date(lesson.scheduledStart);
+            this.calendarLessonDates.add(this.toDateKey(d));
+          }
+          this.buildCalendar();
+          this.cdr.detectChanges();
+        },
+        error: () => {
+          this.buildCalendar();
+          this.cdr.detectChanges();
+        },
+      });
+  }
+
+  private getCalendarRangeStart(): Date {
+    const firstOfMonth = new Date(this.calendarYear, this.calendarMonth, 1);
+    const dow = firstOfMonth.getDay();
+    const offset = dow === 0 ? -6 : 1 - dow;
+    return new Date(this.calendarYear, this.calendarMonth, 1 + offset);
+  }
+
+  private getCalendarRangeEnd(): Date {
+    const start = this.getCalendarRangeStart();
+    const end = new Date(start);
+    end.setDate(start.getDate() + 41);
+    end.setHours(23, 59, 59, 999);
+    return end;
   }
 
   // --- Filtering & Grouping ---
@@ -280,6 +323,15 @@ export class LessonPlanPage implements OnInit {
 
   // --- Mini calendar ---
 
+  toggleCalendar(): void {
+    this.showCalendar = !this.showCalendar;
+    if (this.showCalendar) {
+      this.calendarYear = this.currentDate.getFullYear();
+      this.calendarMonth = this.currentDate.getMonth();
+      this.loadCalendarDots();
+    }
+  }
+
   buildCalendar(): void {
     const year = this.calendarYear;
     const month = this.calendarMonth;
@@ -302,7 +354,7 @@ export class LessonPlanPage implements OnInit {
         day: d.getDate(),
         isCurrentMonth: d.getMonth() === month,
         isToday: d.getTime() === today.getTime(),
-        hasLesson: this.lessonDateStrings.has(this.toDateKey(d)),
+        hasLesson: this.calendarLessonDates.has(this.toDateKey(d)),
       });
       current.setDate(current.getDate() + 1);
     }
@@ -315,7 +367,7 @@ export class LessonPlanPage implements OnInit {
     } else {
       this.calendarMonth--;
     }
-    this.buildCalendar();
+    this.loadCalendarDots();
   }
 
   nextCalendarMonth(): void {
@@ -325,7 +377,7 @@ export class LessonPlanPage implements OnInit {
     } else {
       this.calendarMonth++;
     }
-    this.buildCalendar();
+    this.loadCalendarDots();
   }
 
   get calendarMonthLabel(): string {
@@ -335,8 +387,7 @@ export class LessonPlanPage implements OnInit {
 
   onCalendarDayClick(day: CalendarDay): void {
     this.currentDate = new Date(day.date);
-    this.calendarYear = day.date.getFullYear();
-    this.calendarMonth = day.date.getMonth();
+    this.showCalendar = false;
     this.loadPeriodLessons();
   }
 
@@ -359,6 +410,10 @@ export class LessonPlanPage implements OnInit {
       case 'active': return 'In Progress';
       case 'completed': return 'Completed';
     }
+  }
+
+  isPastWithoutAttendance(lesson: ScheduledLesson): boolean {
+    return this.getLessonStatus(lesson) === 'completed' && !lesson.hasAttendance;
   }
 
   // --- Format ---
@@ -494,13 +549,19 @@ export class LessonPlanPage implements OnInit {
     this.selectedScheduledLesson = lesson;
     this.showAttendanceModal = true;
     this.loadingAttendance = true;
+    this.savingAttendance = false;
+    this.attendanceDirty = false;
     this.studentAttendances = [];
+    this.localAttendanceState.clear();
 
     this.lessonPlanService.getScheduledLessonStudents(lesson.id)
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (data) => {
           this.studentAttendances = data;
+          for (const s of data) {
+            this.localAttendanceState.set(s.studentId, s.isPresent);
+          }
           this.loadingAttendance = false;
           this.cdr.detectChanges();
         },
@@ -515,25 +576,44 @@ export class LessonPlanPage implements OnInit {
   closeAttendanceModal(): void {
     this.showAttendanceModal = false;
     this.selectedScheduledLesson = null;
+    this.localAttendanceState.clear();
+    this.attendanceDirty = false;
     this.cdr.detectChanges();
   }
 
   toggleAttendance(student: StudentAttendance): void {
+    const current = this.localAttendanceState.get(student.studentId) ?? false;
+    this.localAttendanceState.set(student.studentId, !current);
+    this.attendanceDirty = true;
+  }
+
+  isStudentPresent(student: StudentAttendance): boolean {
+    return this.localAttendanceState.get(student.studentId) ?? false;
+  }
+
+  saveAttendance(): void {
     if (!this.selectedScheduledLesson) return;
 
-    const newValue = !student.isPresent;
-    this.lessonPlanService.toggleStudentAttendance(this.selectedScheduledLesson.id, {
-      studentId: student.studentId,
-      isPresent: newValue,
-    })
+    this.savingAttendance = true;
+    const attendances = this.studentAttendances.map(s => ({
+      studentId: s.studentId,
+      isPresent: this.localAttendanceState.get(s.studentId) ?? false,
+    }));
+
+    this.lessonPlanService.saveAttendance(this.selectedScheduledLesson.id, { attendances })
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: () => {
-          student.isPresent = newValue;
-          this.cdr.detectChanges();
+          this.savingAttendance = false;
+          this.attendanceDirty = false;
+          this.success = 'Attendance saved successfully';
+          this.closeAttendanceModal();
+          this.loadPeriodLessons();
+          setTimeout(() => { this.success = ''; this.cdr.detectChanges(); }, 3000);
         },
         error: (err) => {
-          this.error = err.detail || 'Failed to update attendance';
+          this.savingAttendance = false;
+          this.error = err.detail || 'Failed to save attendance';
           this.cdr.detectChanges();
           setTimeout(() => { this.error = ''; this.cdr.detectChanges(); }, 5000);
         },

--- a/src/TeacherSuite.Web/src/teacher-suite-ui/src/app/pages/lesson-plan/lesson-plan.ts
+++ b/src/TeacherSuite.Web/src/teacher-suite-ui/src/app/pages/lesson-plan/lesson-plan.ts
@@ -1,0 +1,309 @@
+import { Component, OnInit, ChangeDetectorRef, DestroyRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { Router } from '@angular/router';
+import { LessonPlanService, ScheduledLesson, StudentAttendance } from '../../services/lesson-plan.service';
+import { LessonService, Lesson } from '../../services/lesson.service';
+import { CourseService, Course } from '../../services/course.service';
+import { GroupService, Group } from '../../services/group.service';
+import { KeycloakService } from '../../auth/keycloak.service';
+import { NgIconComponent, provideIcons } from '@ng-icons/core';
+import {
+  heroCalendarDays,
+  heroPlus,
+  heroClock,
+  heroUserGroup,
+  heroBookOpen,
+  heroEye,
+  heroCheck,
+  heroXMark,
+  heroChevronRight,
+} from '@ng-icons/heroicons/outline';
+
+@Component({
+  selector: 'app-lesson-plan',
+  imports: [CommonModule, ReactiveFormsModule, NgIconComponent],
+  providers: [
+    provideIcons({
+      heroCalendarDays,
+      heroPlus,
+      heroClock,
+      heroUserGroup,
+      heroBookOpen,
+      heroEye,
+      heroCheck,
+      heroXMark,
+      heroChevronRight,
+    }),
+  ],
+  templateUrl: './lesson-plan.html',
+  styleUrl: './lesson-plan.scss',
+})
+export class LessonPlanPage implements OnInit {
+  private destroyRef = inject(DestroyRef);
+
+  scheduledLessons: ScheduledLesson[] = [];
+  loading = true;
+  error = '';
+  success = '';
+
+  // Schedule modal
+  showScheduleModal = false;
+  scheduleForm: FormGroup;
+  courses: Course[] = [];
+  lessons: Lesson[] = [];
+  groups: { id: string; name: string }[] = [];
+  loadingCourses = false;
+  loadingLessons = false;
+  loadingGroups = false;
+
+  // Attendance modal
+  showAttendanceModal = false;
+  selectedScheduledLesson: ScheduledLesson | null = null;
+  studentAttendances: StudentAttendance[] = [];
+  loadingAttendance = false;
+
+  isAdminOrSupervisor = false;
+
+  constructor(
+    private lessonPlanService: LessonPlanService,
+    private lessonService: LessonService,
+    private courseService: CourseService,
+    private groupService: GroupService,
+    private keycloak: KeycloakService,
+    private fb: FormBuilder,
+    private cdr: ChangeDetectorRef,
+    private router: Router
+  ) {
+    this.isAdminOrSupervisor = this.keycloak.hasRole('Admin') || this.keycloak.hasRole('Supervisor');
+
+    this.scheduleForm = this.fb.group({
+      courseId: ['', [Validators.required]],
+      lessonId: ['', [Validators.required]],
+      groupId: ['', [Validators.required]],
+      scheduledStart: ['', [Validators.required]],
+    });
+  }
+
+  ngOnInit(): void {
+    this.loadLessonPlan();
+  }
+
+  loadLessonPlan(): void {
+    this.loading = true;
+    this.error = '';
+
+    this.lessonPlanService.getLessonPlan()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (data) => {
+          this.scheduledLessons = data;
+          this.loading = false;
+          this.cdr.detectChanges();
+        },
+        error: (err) => {
+          this.error = err.detail || 'Failed to load lesson plan';
+          this.loading = false;
+          this.cdr.detectChanges();
+        },
+      });
+  }
+
+  getLessonStatus(lesson: ScheduledLesson): 'upcoming' | 'active' | 'completed' {
+    const now = new Date();
+    const start = new Date(lesson.scheduledStart);
+    const end = new Date(lesson.scheduledEnd);
+
+    if (now < start) return 'upcoming';
+    if (now >= start && now <= end) return 'active';
+    return 'completed';
+  }
+
+  getStatusLabel(lesson: ScheduledLesson): string {
+    const status = this.getLessonStatus(lesson);
+    switch (status) {
+      case 'upcoming': return 'Upcoming';
+      case 'active': return 'In Progress';
+      case 'completed': return 'Completed';
+    }
+  }
+
+  navigateToLesson(lessonId: number): void {
+    this.router.navigate(['/lessons', lessonId]);
+  }
+
+  // Schedule modal
+  openScheduleModal(): void {
+    this.showScheduleModal = true;
+    this.scheduleForm.reset();
+    this.lessons = [];
+    this.groups = [];
+    this.loadCourses();
+    this.cdr.detectChanges();
+  }
+
+  closeScheduleModal(): void {
+    this.showScheduleModal = false;
+    this.cdr.detectChanges();
+  }
+
+  loadCourses(): void {
+    this.loadingCourses = true;
+    this.courseService.getAllCourses({ page: 1, pageSize: 100 })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (result) => {
+          this.courses = result.items;
+          this.loadingCourses = false;
+          this.cdr.detectChanges();
+        },
+        error: () => {
+          this.loadingCourses = false;
+          this.cdr.detectChanges();
+        },
+      });
+  }
+
+  onCourseChange(): void {
+    const courseId = +this.scheduleForm.get('courseId')?.value;
+    if (!courseId) {
+      this.lessons = [];
+      this.groups = [];
+      return;
+    }
+
+    this.loadingLessons = true;
+    this.loadingGroups = true;
+    this.scheduleForm.patchValue({ lessonId: '', groupId: '' });
+
+    this.lessonService.getLessonsByCourse(courseId)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (data) => {
+          this.lessons = data;
+          this.loadingLessons = false;
+          this.cdr.detectChanges();
+        },
+        error: () => {
+          this.loadingLessons = false;
+          this.cdr.detectChanges();
+        },
+      });
+
+    this.lessonService.getCourseGroups(courseId)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (data) => {
+          this.groups = data;
+          this.loadingGroups = false;
+          this.cdr.detectChanges();
+        },
+        error: () => {
+          this.loadingGroups = false;
+          this.cdr.detectChanges();
+        },
+      });
+  }
+
+  scheduleLesson(): void {
+    if (this.scheduleForm.invalid) return;
+
+    const val = this.scheduleForm.value;
+    this.lessonPlanService.createScheduledLesson({
+      lessonId: +val.lessonId,
+      groupId: val.groupId,
+      scheduledStart: new Date(val.scheduledStart).toISOString(),
+    })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: () => {
+          this.success = 'Lesson scheduled successfully';
+          this.closeScheduleModal();
+          this.loadLessonPlan();
+          setTimeout(() => { this.success = ''; this.cdr.detectChanges(); }, 3000);
+        },
+        error: (err) => {
+          this.error = err.detail || 'Failed to schedule lesson';
+          this.cdr.detectChanges();
+          setTimeout(() => { this.error = ''; this.cdr.detectChanges(); }, 5000);
+        },
+      });
+  }
+
+  // Attendance modal
+  openAttendanceModal(lesson: ScheduledLesson): void {
+    this.selectedScheduledLesson = lesson;
+    this.showAttendanceModal = true;
+    this.loadingAttendance = true;
+    this.studentAttendances = [];
+
+    this.lessonPlanService.getScheduledLessonStudents(lesson.id)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (data) => {
+          this.studentAttendances = data;
+          this.loadingAttendance = false;
+          this.cdr.detectChanges();
+        },
+        error: (err) => {
+          this.error = err.detail || 'Failed to load students';
+          this.loadingAttendance = false;
+          this.cdr.detectChanges();
+        },
+      });
+  }
+
+  closeAttendanceModal(): void {
+    this.showAttendanceModal = false;
+    this.selectedScheduledLesson = null;
+    this.cdr.detectChanges();
+  }
+
+  toggleAttendance(student: StudentAttendance): void {
+    if (!this.selectedScheduledLesson) return;
+
+    const newValue = !student.isPresent;
+    this.lessonPlanService.toggleStudentAttendance(this.selectedScheduledLesson.id, {
+      studentId: student.studentId,
+      isPresent: newValue,
+    })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: () => {
+          student.isPresent = newValue;
+          this.cdr.detectChanges();
+        },
+        error: (err) => {
+          this.error = err.detail || 'Failed to update attendance';
+          this.cdr.detectChanges();
+          setTimeout(() => { this.error = ''; this.cdr.detectChanges(); }, 5000);
+        },
+      });
+  }
+
+  formatDateTime(dateString: string): string {
+    if (!dateString) return 'N/A';
+    const date = new Date(dateString);
+    if (isNaN(date.getTime())) return 'Invalid Date';
+    return date.toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+      timeZone: 'UTC',
+    });
+  }
+
+  formatTime(dateString: string): string {
+    if (!dateString) return 'N/A';
+    const date = new Date(dateString);
+    if (isNaN(date.getTime())) return 'Invalid';
+    return date.toLocaleTimeString('en-US', {
+      hour: '2-digit',
+      minute: '2-digit',
+      timeZone: 'UTC',
+    });
+  }
+}

--- a/src/TeacherSuite.Web/src/teacher-suite-ui/src/app/pages/lesson-plan/lesson-plan.ts
+++ b/src/TeacherSuite.Web/src/teacher-suite-ui/src/app/pages/lesson-plan/lesson-plan.ts
@@ -237,10 +237,7 @@ export class LessonPlanPage implements OnInit {
       courseSet.add(lesson.courseName);
       groupSet.add(lesson.groupName);
       const d = new Date(lesson.scheduledStart);
-      const dateStr = d.getFullYear() + '-' +
-        String(d.getMonth() + 1).padStart(2, '0') + '-' +
-        String(d.getDate()).padStart(2, '0');
-      this.lessonDateStrings.add(dateStr);
+      this.lessonDateStrings.add(this.toDateKey(d));
     }
 
     this.availableCourses = Array.from(courseSet).sort();
@@ -300,16 +297,12 @@ export class LessonPlanPage implements OnInit {
     for (let i = 0; i < 42; i++) {
       const d = new Date(current);
       d.setHours(0, 0, 0, 0);
-      const dateStr = d.getFullYear() + '-' +
-        String(d.getMonth() + 1).padStart(2, '0') + '-' +
-        String(d.getDate()).padStart(2, '0');
-
       this.calendarDays.push({
         date: new Date(d),
         day: d.getDate(),
         isCurrentMonth: d.getMonth() === month,
         isToday: d.getTime() === today.getTime(),
-        hasLesson: this.lessonDateStrings.has(dateStr),
+        hasLesson: this.lessonDateStrings.has(this.toDateKey(d)),
       });
       current.setDate(current.getDate() + 1);
     }
@@ -370,7 +363,13 @@ export class LessonPlanPage implements OnInit {
 
   // --- Format ---
 
-  formatDateStart(dateString: string): string {
+  private toDateKey(d: Date): string {
+    return d.getFullYear() + '-' +
+      String(d.getMonth() + 1).padStart(2, '0') + '-' +
+      String(d.getDate()).padStart(2, '0');
+  }
+
+  formatScheduledDateTime(dateString: string): string {
     if (!dateString) return 'N/A';
     const date = new Date(dateString);
     if (isNaN(date.getTime())) return 'Invalid Date';

--- a/src/TeacherSuite.Web/src/teacher-suite-ui/src/app/services/lesson-plan.service.ts
+++ b/src/TeacherSuite.Web/src/teacher-suite-ui/src/app/services/lesson-plan.service.ts
@@ -13,6 +13,7 @@ export interface ScheduledLesson {
   lessonOrder: number;
   scheduledStart: string;
   scheduledEnd: string;
+  hasAttendance: boolean;
 }
 
 export interface StudentAttendance {
@@ -32,6 +33,10 @@ export interface CreateScheduledLessonDto {
 export interface ToggleAttendanceDto {
   studentId: string;
   isPresent: boolean;
+}
+
+export interface SaveAttendanceDto {
+  attendances: { studentId: string; isPresent: boolean }[];
 }
 
 @Injectable({
@@ -58,5 +63,9 @@ export class LessonPlanService extends ApiService {
 
   toggleStudentAttendance(scheduledLessonId: string, dto: ToggleAttendanceDto): Observable<string> {
     return this.post<string>(`${this.apiUrl}/${scheduledLessonId}/attendance`, dto);
+  }
+
+  saveAttendance(scheduledLessonId: string, dto: SaveAttendanceDto): Observable<void> {
+    return this.post<void>(`${this.apiUrl}/${scheduledLessonId}/attendance/save`, dto);
   }
 }

--- a/src/TeacherSuite.Web/src/teacher-suite-ui/src/app/services/lesson-plan.service.ts
+++ b/src/TeacherSuite.Web/src/teacher-suite-ui/src/app/services/lesson-plan.service.ts
@@ -1,0 +1,62 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ApiService } from './api.service';
+
+export interface ScheduledLesson {
+  id: string;
+  lessonId: number;
+  groupId: string;
+  groupName: string;
+  lessonTitle: string;
+  courseName: string;
+  courseId: number;
+  lessonOrder: number;
+  scheduledStart: string;
+  scheduledEnd: string;
+}
+
+export interface StudentAttendance {
+  id: string;
+  studentId: string;
+  studentFirstName: string;
+  studentLastName: string;
+  isPresent: boolean;
+}
+
+export interface CreateScheduledLessonDto {
+  lessonId: number;
+  groupId: string;
+  scheduledStart: string;
+}
+
+export interface ToggleAttendanceDto {
+  studentId: string;
+  isPresent: boolean;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class LessonPlanService extends ApiService {
+  private readonly apiUrl = '/LessonPlan';
+
+  getLessonPlan(from?: string, to?: string): Observable<ScheduledLesson[]> {
+    const params = new URLSearchParams();
+    if (from) params.append('from', from);
+    if (to) params.append('to', to);
+    const query = params.toString();
+    return this.get<ScheduledLesson[]>(`${this.apiUrl}${query ? '?' + query : ''}`);
+  }
+
+  createScheduledLesson(dto: CreateScheduledLessonDto): Observable<string> {
+    return this.post<string>(this.apiUrl, dto);
+  }
+
+  getScheduledLessonStudents(scheduledLessonId: string): Observable<StudentAttendance[]> {
+    return this.get<StudentAttendance[]>(`${this.apiUrl}/${scheduledLessonId}/students`);
+  }
+
+  toggleStudentAttendance(scheduledLessonId: string, dto: ToggleAttendanceDto): Observable<string> {
+    return this.post<string>(`${this.apiUrl}/${scheduledLessonId}/attendance`, dto);
+  }
+}

--- a/tests/Application.UnitTests/GetLessonPlanQueryTests.cs
+++ b/tests/Application.UnitTests/GetLessonPlanQueryTests.cs
@@ -1,0 +1,317 @@
+using AutoMapper;
+using Moq;
+using TeacherSuite.Application.Common.Interfaces;
+using TeacherSuite.Application.LessonPlan.Dtos;
+using TeacherSuite.Application.LessonPlan.Queries;
+using TeacherSuite.Domain.Common;
+using TeacherSuite.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.EntityFrameworkCore.Query;
+
+namespace Application.UnitTests;
+
+public class GetLessonPlanQueryTests
+{
+    private readonly IMapper _mapper;
+    private readonly Mock<ICurrentUserService> _mockCurrentUser;
+
+    public GetLessonPlanQueryTests()
+    {
+        var config = new MapperConfiguration(
+            cfg => cfg.AddMaps(typeof(ScheduledLessonDto).Assembly),
+            NullLoggerFactory.Instance);
+        _mapper = config.CreateMapper();
+
+        _mockCurrentUser = new Mock<ICurrentUserService>();
+        _mockCurrentUser.Setup(x => x.IsInRole(AppRoles.Admin)).Returns(true);
+        _mockCurrentUser.Setup(x => x.IsInRole(AppRoles.Teacher)).Returns(false);
+        _mockCurrentUser.Setup(x => x.IsInRole(AppRoles.Supervisor)).Returns(false);
+        _mockCurrentUser.Setup(x => x.IsAuthenticated).Returns(true);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsAllScheduledLessons_ForAdmin()
+    {
+        // Arrange
+        var course = new Course { Id = 1, Name = "Python Basics" };
+        var group = new Group { Id = Guid.NewGuid(), Name = "Group A", TeacherId = Guid.NewGuid() };
+        var lesson = new Lesson { Id = 1, CourseId = 1, Course = course, Title = "Lesson 1", Order = 1, DurationMinutes = 90 };
+
+        var now = DateTimeOffset.UtcNow;
+        var scheduledLessons = new List<ScheduledLesson>
+        {
+            new()
+            {
+                Id = Guid.NewGuid(),
+                LessonId = 1,
+                Lesson = lesson,
+                GroupId = group.Id,
+                Group = group,
+                ScheduledStart = now.AddHours(1),
+                ScheduledEnd = now.AddHours(2.5),
+            },
+            new()
+            {
+                Id = Guid.NewGuid(),
+                LessonId = 1,
+                Lesson = lesson,
+                GroupId = group.Id,
+                Group = group,
+                ScheduledStart = now.AddDays(1),
+                ScheduledEnd = now.AddDays(1).AddMinutes(90),
+            }
+        };
+
+        var mockDbSet = CreateMockDbSet(scheduledLessons.AsQueryable());
+        var mockDb = new Mock<IApplicationDbContext>();
+        mockDb.Setup(x => x.ScheduledLessons).Returns(mockDbSet.Object);
+
+        var handler = new GetLessonPlanQueryHandler(mockDb.Object, _mapper, _mockCurrentUser.Object);
+
+        // Act
+        var result = await handler.Handle(new GetLessonPlanQuery(null, null), CancellationToken.None);
+
+        // Assert
+        Assert.Equal(2, result.Count);
+        Assert.Equal("Lesson 1", result[0].LessonTitle);
+        Assert.Equal("Group A", result[0].GroupName);
+        Assert.Equal("Python Basics", result[0].CourseName);
+    }
+
+    [Fact]
+    public async Task Handle_FiltersScheduledLessons_ByDateRange()
+    {
+        // Arrange
+        var course = new Course { Id = 1, Name = "Python Basics" };
+        var group = new Group { Id = Guid.NewGuid(), Name = "Group A", TeacherId = Guid.NewGuid() };
+        var lesson = new Lesson { Id = 1, CourseId = 1, Course = course, Title = "Lesson 1", Order = 1, DurationMinutes = 90 };
+
+        var now = DateTimeOffset.UtcNow;
+        var scheduledLessons = new List<ScheduledLesson>
+        {
+            new()
+            {
+                Id = Guid.NewGuid(),
+                LessonId = 1,
+                Lesson = lesson,
+                GroupId = group.Id,
+                Group = group,
+                ScheduledStart = now.AddDays(-2),
+                ScheduledEnd = now.AddDays(-2).AddMinutes(90),
+            },
+            new()
+            {
+                Id = Guid.NewGuid(),
+                LessonId = 1,
+                Lesson = lesson,
+                GroupId = group.Id,
+                Group = group,
+                ScheduledStart = now.AddHours(1),
+                ScheduledEnd = now.AddHours(2.5),
+            }
+        };
+
+        var mockDbSet = CreateMockDbSet(scheduledLessons.AsQueryable());
+        var mockDb = new Mock<IApplicationDbContext>();
+        mockDb.Setup(x => x.ScheduledLessons).Returns(mockDbSet.Object);
+
+        var handler = new GetLessonPlanQueryHandler(mockDb.Object, _mapper, _mockCurrentUser.Object);
+
+        // Act - filter from now onwards
+        var result = await handler.Handle(new GetLessonPlanQuery(now, null), CancellationToken.None);
+
+        // Assert
+        Assert.Single(result);
+        Assert.True(new DateTimeOffset(result[0].ScheduledEnd.DateTime, TimeSpan.Zero) >= now);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsEmpty_WhenNoScheduledLessons()
+    {
+        // Arrange
+        var scheduledLessons = new List<ScheduledLesson>();
+        var mockDbSet = CreateMockDbSet(scheduledLessons.AsQueryable());
+        var mockDb = new Mock<IApplicationDbContext>();
+        mockDb.Setup(x => x.ScheduledLessons).Returns(mockDbSet.Object);
+
+        var handler = new GetLessonPlanQueryHandler(mockDb.Object, _mapper, _mockCurrentUser.Object);
+
+        // Act
+        var result = await handler.Handle(new GetLessonPlanQuery(null, null), CancellationToken.None);
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsOrderedByScheduledStart()
+    {
+        // Arrange
+        var course = new Course { Id = 1, Name = "Python Basics" };
+        var group = new Group { Id = Guid.NewGuid(), Name = "Group A", TeacherId = Guid.NewGuid() };
+
+        var now = DateTimeOffset.UtcNow;
+        var scheduledLessons = new List<ScheduledLesson>
+        {
+            new()
+            {
+                Id = Guid.NewGuid(),
+                LessonId = 1,
+                Lesson = new Lesson { Id = 1, CourseId = 1, Course = course, Title = "Later Lesson", Order = 2, DurationMinutes = 90 },
+                GroupId = group.Id,
+                Group = group,
+                ScheduledStart = now.AddDays(2),
+                ScheduledEnd = now.AddDays(2).AddMinutes(90),
+            },
+            new()
+            {
+                Id = Guid.NewGuid(),
+                LessonId = 2,
+                Lesson = new Lesson { Id = 2, CourseId = 1, Course = course, Title = "Earlier Lesson", Order = 1, DurationMinutes = 90 },
+                GroupId = group.Id,
+                Group = group,
+                ScheduledStart = now.AddDays(1),
+                ScheduledEnd = now.AddDays(1).AddMinutes(90),
+            }
+        };
+
+        var mockDbSet = CreateMockDbSet(scheduledLessons.AsQueryable());
+        var mockDb = new Mock<IApplicationDbContext>();
+        mockDb.Setup(x => x.ScheduledLessons).Returns(mockDbSet.Object);
+
+        var handler = new GetLessonPlanQueryHandler(mockDb.Object, _mapper, _mockCurrentUser.Object);
+
+        // Act
+        var result = await handler.Handle(new GetLessonPlanQuery(null, null), CancellationToken.None);
+
+        // Assert
+        Assert.Equal(2, result.Count);
+        Assert.Equal("Earlier Lesson", result[0].LessonTitle);
+        Assert.Equal("Later Lesson", result[1].LessonTitle);
+    }
+
+    [Fact]
+    public async Task Handle_TeacherOnlyUser_ReturnsOwnGroupsOnly()
+    {
+        // Arrange
+        var teacherId = Guid.NewGuid();
+        var otherTeacherId = Guid.NewGuid();
+        var teacherEmail = "teacher@example.com";
+
+        var mockTeacherUser = new Mock<ICurrentUserService>();
+        mockTeacherUser.Setup(x => x.IsInRole(AppRoles.Admin)).Returns(false);
+        mockTeacherUser.Setup(x => x.IsInRole(AppRoles.Supervisor)).Returns(false);
+        mockTeacherUser.Setup(x => x.IsInRole(AppRoles.Teacher)).Returns(true);
+        mockTeacherUser.Setup(x => x.Email).Returns(teacherEmail);
+
+        var teacher = new Teacher
+        {
+            Id = teacherId,
+            Email = teacherEmail,
+            FirstName = "John",
+            LastName = "Doe"
+        };
+
+        var course = new Course { Id = 1, Name = "Python Basics" };
+        var myGroup = new Group { Id = Guid.NewGuid(), Name = "My Group", TeacherId = teacherId };
+        var otherGroup = new Group { Id = Guid.NewGuid(), Name = "Other Group", TeacherId = otherTeacherId };
+
+        var now = DateTimeOffset.UtcNow;
+        var scheduledLessons = new List<ScheduledLesson>
+        {
+            new()
+            {
+                Id = Guid.NewGuid(),
+                LessonId = 1,
+                Lesson = new Lesson { Id = 1, CourseId = 1, Course = course, Title = "My Lesson", Order = 1, DurationMinutes = 90 },
+                GroupId = myGroup.Id,
+                Group = myGroup,
+                ScheduledStart = now.AddHours(1),
+                ScheduledEnd = now.AddHours(2.5),
+            },
+            new()
+            {
+                Id = Guid.NewGuid(),
+                LessonId = 2,
+                Lesson = new Lesson { Id = 2, CourseId = 1, Course = course, Title = "Other Lesson", Order = 2, DurationMinutes = 90 },
+                GroupId = otherGroup.Id,
+                Group = otherGroup,
+                ScheduledStart = now.AddHours(1),
+                ScheduledEnd = now.AddHours(2.5),
+            }
+        };
+
+        var teachers = new List<Teacher> { teacher };
+        var mockScheduledDbSet = CreateMockDbSet(scheduledLessons.AsQueryable());
+        var mockTeacherDbSet = CreateMockDbSet(teachers.AsQueryable());
+
+        var mockDb = new Mock<IApplicationDbContext>();
+        mockDb.Setup(x => x.ScheduledLessons).Returns(mockScheduledDbSet.Object);
+        mockDb.Setup(x => x.Teachers).Returns(mockTeacherDbSet.Object);
+
+        var handler = new GetLessonPlanQueryHandler(mockDb.Object, _mapper, mockTeacherUser.Object);
+
+        // Act
+        var result = await handler.Handle(new GetLessonPlanQuery(null, null), CancellationToken.None);
+
+        // Assert
+        Assert.Single(result);
+        Assert.Equal("My Lesson", result[0].LessonTitle);
+        Assert.Equal("My Group", result[0].GroupName);
+    }
+
+    [Fact]
+    public async Task Handle_TeacherNotFound_ReturnsEmpty()
+    {
+        // Arrange
+        var mockTeacherUser = new Mock<ICurrentUserService>();
+        mockTeacherUser.Setup(x => x.IsInRole(AppRoles.Admin)).Returns(false);
+        mockTeacherUser.Setup(x => x.IsInRole(AppRoles.Supervisor)).Returns(false);
+        mockTeacherUser.Setup(x => x.IsInRole(AppRoles.Teacher)).Returns(true);
+        mockTeacherUser.Setup(x => x.Email).Returns("nonexistent@example.com");
+
+        var teachers = new List<Teacher>();
+        var scheduledLessons = new List<ScheduledLesson>
+        {
+            new()
+            {
+                Id = Guid.NewGuid(),
+                LessonId = 1,
+                Lesson = new Lesson { Id = 1, CourseId = 1, Title = "Lesson 1", Order = 1, DurationMinutes = 90 },
+                GroupId = Guid.NewGuid(),
+                Group = new Group { Id = Guid.NewGuid(), Name = "Group A", TeacherId = Guid.NewGuid() },
+                ScheduledStart = DateTimeOffset.UtcNow.AddHours(1),
+                ScheduledEnd = DateTimeOffset.UtcNow.AddHours(2.5),
+            }
+        };
+
+        var mockScheduledDbSet = CreateMockDbSet(scheduledLessons.AsQueryable());
+        var mockTeacherDbSet = CreateMockDbSet(teachers.AsQueryable());
+
+        var mockDb = new Mock<IApplicationDbContext>();
+        mockDb.Setup(x => x.ScheduledLessons).Returns(mockScheduledDbSet.Object);
+        mockDb.Setup(x => x.Teachers).Returns(mockTeacherDbSet.Object);
+
+        var handler = new GetLessonPlanQueryHandler(mockDb.Object, _mapper, mockTeacherUser.Object);
+
+        // Act
+        var result = await handler.Handle(new GetLessonPlanQuery(null, null), CancellationToken.None);
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    private static Mock<DbSet<T>> CreateMockDbSet<T>(IQueryable<T> data) where T : class
+    {
+        var mockSet = new Mock<DbSet<T>>();
+        mockSet.As<IAsyncEnumerable<T>>()
+            .Setup(m => m.GetAsyncEnumerator(It.IsAny<CancellationToken>()))
+            .Returns(new TestAsyncEnumerator<T>(data.GetEnumerator()));
+        mockSet.As<IQueryable<T>>().Setup(m => m.Provider).Returns(new TestAsyncQueryProvider<T>(data.Provider));
+        mockSet.As<IQueryable<T>>().Setup(m => m.Expression).Returns(data.Expression);
+        mockSet.As<IQueryable<T>>().Setup(m => m.ElementType).Returns(data.ElementType);
+        mockSet.As<IQueryable<T>>().Setup(m => m.GetEnumerator()).Returns(data.GetEnumerator());
+        return mockSet;
+    }
+}

--- a/tests/Application.UnitTests/GetLessonPlanQueryTests.cs
+++ b/tests/Application.UnitTests/GetLessonPlanQueryTests.cs
@@ -123,7 +123,7 @@ public class GetLessonPlanQueryTests
 
         // Assert
         Assert.Single(result);
-        Assert.True(new DateTimeOffset(result[0].ScheduledEnd.DateTime, TimeSpan.Zero) >= now);
+        Assert.True(result[0].ScheduledEnd >= now);
     }
 
     [Fact]


### PR DESCRIPTION
Teachers need a view of upcoming scheduled lessons with automatic status indicators (active/upcoming/completed based on current time), per-student attendance tracking, and quick navigation to lesson details.

**Domain**
ScheduledLesson — binds a Lesson to a Group at a specific ScheduledStart/ScheduledEnd. End time auto-computed from lesson duration.
StudentLessonAttendance — per-student presence record for a scheduled lesson. Unique on (ScheduledLessonId, StudentId).

**Backend**
GetLessonPlanQuery — returns scheduled lessons ordered by start time. Teacher-only users are scoped to their own groups via Teacher.Email == ICurrentUserService.Email. Supports optional From/To date filtering.
GetScheduledLessonStudentsQuery — returns all students in the group with their attendance status (joins StudentGroup with existing StudentLessonAttendance records).
CreateScheduledLessonCommand — validates group is assigned to the lesson's course, prevents duplicate scheduling at same time.
ToggleStudentAttendanceCommand — upserts attendance record (create or update IsPresent).
Endpoints at /LessonPlan with AdminSupervisorOrTeacher authorization.

**Frontend**
LessonPlanPage at /lesson-plan with sidebar nav link.
Lesson status computed client-side: green border = in progress (now ∈ [start, end]), blue = upcoming, grey = completed.
Schedule modal with cascading course → lesson/group selectors.
Attendance modal: click-to-toggle student presence.
"Details" button navigates to existing /lessons/:id detail page.
