### PR TITLE
Add Web API rate limiting (sliding-window per-user/IP)

### DIFF
--- a/src/TeacherSuite.Web/Middleware/RateLimitingMiddlewareExtensions.cs
+++ b/src/TeacherSuite.Web/Middleware/RateLimitingMiddlewareExtensions.cs
@@ -1,0 +1,65 @@
+using System.Threading.RateLimiting;
+
+namespace TeacherSuite.Web.Middleware;
+
+public static class RateLimitingMiddlewareExtensions
+{
+    private static readonly TimeSpan Window = TimeSpan.FromSeconds(60);
+    private static readonly TimeSpan DefaultRetryAfter = TimeSpan.FromSeconds(10);
+
+    public static IServiceCollection AddWebApiRateLimiting(this IServiceCollection services)
+    {
+        services.AddRateLimiter(options =>
+        {
+            options.GlobalLimiter = PartitionedRateLimiter.Create<HttpContext, string>(httpContext =>
+            {
+                var partitionKey = httpContext.User.Identity?.Name;
+                if (string.IsNullOrWhiteSpace(partitionKey))
+                {
+                    partitionKey = httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown-ip";
+                }
+
+                return RateLimitPartition.GetSlidingWindowLimiter(
+                    partitionKey,
+                    _ => new SlidingWindowRateLimiterOptions
+                    {
+                        PermitLimit = 10,
+                        Window = Window,
+                        SegmentsPerWindow = 6,
+                        QueueLimit = 0,
+                        AutoReplenishment = true,
+                    });
+            });
+
+            options.OnRejected = async (context, cancellationToken) =>
+            {
+                context.HttpContext.Response.StatusCode = StatusCodes.Status429TooManyRequests;
+                context.HttpContext.Response.ContentType = "application/json";
+
+                var retryAfter = DefaultRetryAfter;
+                if (context.Lease.TryGetMetadata(MetadataName.RetryAfter, out var retryAfterMetadata))
+                {
+                    retryAfter = retryAfterMetadata;
+                }
+
+                context.HttpContext.Response.Headers.RetryAfter = Math.Ceiling(retryAfter.TotalSeconds).ToString();
+
+                await context.HttpContext.Response.WriteAsJsonAsync(
+                    new
+                    {
+                        status = StatusCodes.Status429TooManyRequests,
+                        title = "Too many requests",
+                        detail = "Rate limit exceeded. Please retry after the number of seconds specified in the Retry-After header.",
+                    },
+                    cancellationToken);
+            };
+        });
+
+        return services;
+    }
+
+    public static IApplicationBuilder UseWebApiRateLimiting(this IApplicationBuilder app)
+    {
+        return app.UseRateLimiter();
+    }
+}

--- a/src/TeacherSuite.Web/Program.cs
+++ b/src/TeacherSuite.Web/Program.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.IdentityModel.Tokens;
+using System.Threading.RateLimiting;
 using TeacherSuite.Application.Common.Interfaces;
 using TeacherSuite.Domain.Common;
 using TeacherSuite.Infrastructure;
@@ -19,6 +20,52 @@ builder.Services.AddInfrastructureServices(builder.Configuration);
 builder.Services.AddHttpContextAccessor();
 builder.Services.AddScoped<ICurrentUserService, CurrentUserService>();
 builder.Services.AddTransient<IClaimsTransformation, KeycloakClaimsTransformation>();
+
+builder.Services.AddRateLimiter(options =>
+{
+    options.GlobalLimiter = PartitionedRateLimiter.Create<HttpContext, string>(httpContext =>
+    {
+        var partitionKey = httpContext.User.Identity?.Name;
+        if (string.IsNullOrWhiteSpace(partitionKey))
+        {
+            partitionKey = httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown-ip";
+        }
+
+        return RateLimitPartition.GetSlidingWindowLimiter(
+            partitionKey,
+            _ => new SlidingWindowRateLimiterOptions
+            {
+                PermitLimit = 10,
+                Window = TimeSpan.FromSeconds(60),
+                SegmentsPerWindow = 6,
+                QueueLimit = 0,
+                AutoReplenishment = true,
+            });
+    });
+
+    options.OnRejected = async (context, cancellationToken) =>
+    {
+        context.HttpContext.Response.StatusCode = StatusCodes.Status429TooManyRequests;
+        context.HttpContext.Response.ContentType = "application/json";
+
+        var retryAfter = TimeSpan.FromSeconds(10);
+        if (context.Lease.TryGetMetadata(MetadataName.RetryAfter, out var retryAfterMetadata))
+        {
+            retryAfter = retryAfterMetadata;
+        }
+
+        context.HttpContext.Response.Headers.RetryAfter = Math.Ceiling(retryAfter.TotalSeconds).ToString();
+
+        await context.HttpContext.Response.WriteAsJsonAsync(
+            new
+            {
+                status = StatusCodes.Status429TooManyRequests,
+                title = "Too many requests",
+                detail = "Rate limit exceeded. Please retry after the number of seconds specified in the Retry-After header.",
+            },
+            cancellationToken);
+    };
+});
 
 var spaOrigin = builder.Configuration["Cors:SpaOrigin"]
     ?? (builder.Environment.IsDevelopment()
@@ -76,6 +123,7 @@ app.UseGlobalExceptionHandler();
 
 app.UseCors();
 app.UseAuthentication();
+app.UseRateLimiter();
 app.UseAuthorization();
 
 if (app.Environment.IsDevelopment()) {

--- a/src/TeacherSuite.Web/Program.cs
+++ b/src/TeacherSuite.Web/Program.cs
@@ -2,7 +2,6 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.IdentityModel.Tokens;
-using System.Threading.RateLimiting;
 using TeacherSuite.Application.Common.Interfaces;
 using TeacherSuite.Domain.Common;
 using TeacherSuite.Infrastructure;
@@ -21,52 +20,7 @@ builder.Services.AddHttpContextAccessor();
 builder.Services.AddScoped<ICurrentUserService, CurrentUserService>();
 builder.Services.AddTransient<IClaimsTransformation, KeycloakClaimsTransformation>();
 
-builder.Services.AddRateLimiter(options =>
-{
-    options.GlobalLimiter = PartitionedRateLimiter.Create<HttpContext, string>(httpContext =>
-    {
-        var partitionKey = httpContext.User.Identity?.Name;
-        if (string.IsNullOrWhiteSpace(partitionKey))
-        {
-            partitionKey = httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown-ip";
-        }
-
-        return RateLimitPartition.GetSlidingWindowLimiter(
-            partitionKey,
-            _ => new SlidingWindowRateLimiterOptions
-            {
-                PermitLimit = 10,
-                Window = TimeSpan.FromSeconds(60),
-                SegmentsPerWindow = 6,
-                QueueLimit = 0,
-                AutoReplenishment = true,
-            });
-    });
-
-    options.OnRejected = async (context, cancellationToken) =>
-    {
-        context.HttpContext.Response.StatusCode = StatusCodes.Status429TooManyRequests;
-        context.HttpContext.Response.ContentType = "application/json";
-
-        var retryAfter = TimeSpan.FromSeconds(10);
-        if (context.Lease.TryGetMetadata(MetadataName.RetryAfter, out var retryAfterMetadata))
-        {
-            retryAfter = retryAfterMetadata;
-        }
-
-        context.HttpContext.Response.Headers.RetryAfter = Math.Ceiling(retryAfter.TotalSeconds).ToString();
-
-        await context.HttpContext.Response.WriteAsJsonAsync(
-            new
-            {
-                status = StatusCodes.Status429TooManyRequests,
-                title = "Too many requests",
-                detail = "Rate limit exceeded. Please retry after the number of seconds specified in the Retry-After header.",
-            },
-            cancellationToken);
-    };
-});
-
+builder.Services.AddWebApiRateLimiting();
 var spaOrigin = builder.Configuration["Cors:SpaOrigin"]
     ?? (builder.Environment.IsDevelopment()
         ? "http://localhost:4200"
@@ -123,7 +77,7 @@ app.UseGlobalExceptionHandler();
 
 app.UseCors();
 app.UseAuthentication();
-app.UseRateLimiter();
+app.UseWebApiRateLimiting();
 app.UseAuthorization();
 
 if (app.Environment.IsDevelopment()) {


### PR DESCRIPTION
### Motivation
- Prevent excessive or malicious API usage by adding server-side rate limiting to the Web API.
- Use the framework-built rate limiting primitives to provide a robust, low-overhead solution.
- Partition limits by authenticated user identity with a remote IP fallback to ensure per-client quotas.

### Description
- Added `using System.Threading.RateLimiting;` and registered a global partitioned rate limiter in `src/TeacherSuite.Web/Program.cs` via `builder.Services.AddRateLimiter(...)`.
- Implemented a sliding-window limiter partitioned by `httpContext.User.Identity?.Name` falling back to `httpContext.Connection.RemoteIpAddress`, with `PermitLimit = 10`, `Window = 60s`, `SegmentsPerWindow = 6`, `QueueLimit = 0`, and `AutoReplenishment = true`.
- Added an `OnRejected` handler that returns a JSON 429 response and always sets a `Retry-After` header (reads limiter metadata `RetryAfter` when available, otherwise falls back to 10 seconds).
- Enabled the middleware with `app.UseRateLimiter()` and positioned it after authentication so partitioning can use the authenticated identity.

### Testing
- Attempted to run `dotnet build TeacherSuite.sln` in the environment but the `dotnet` CLI was not installed so the build could not be executed.
- No automated tests were run in this environment due to the missing `dotnet` toolchain.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34f884f0c48322a40162583cb91b3e)