### PR TITLE
Fix uploaded markdown XSS sanitization

### DIFF
--- a/src/TeacherSuite.Web/src/teacher-suite-ui/src/app/pages/lesson-detail/lesson-detail.spec.ts
+++ b/src/TeacherSuite.Web/src/teacher-suite-ui/src/app/pages/lesson-detail/lesson-detail.spec.ts
@@ -1,0 +1,51 @@
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRoute, provideRouter } from '@angular/router';
+import { of } from 'rxjs';
+import { LessonDetailPage } from './lesson-detail';
+import { KeycloakService } from '../../auth/keycloak.service';
+import { LessonDetail, LessonService } from '../../services/lesson.service';
+
+const lesson: LessonDetail = {
+  id: 1,
+  courseId: 10,
+  order: 1,
+  title: 'Intro lesson',
+  durationMinutes: 45,
+  requirementIcons: [],
+  courseName: 'Course',
+  suggestions: [],
+  attendances: [],
+};
+
+describe('LessonDetailPage', () => {
+  it('renders markdown through Angular sanitization instead of trusting uploaded HTML', async () => {
+    const lessonService = {
+      getLessonById: vi.fn().mockReturnValue(of(lesson)),
+      getLessonFiles: vi.fn().mockReturnValue(of([{ uuid: 'file-1', name: 'lesson.md', size: 100 }])),
+      downloadMaterialAsText: vi.fn().mockResolvedValue(
+        '# Safe heading\n\n<script>window.xss = true;</script><img src="x" onerror="window.xss = true">'
+      ),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [LessonDetailPage],
+      providers: [
+        provideRouter([]),
+        { provide: ActivatedRoute, useValue: { params: of({ id: '1' }) } },
+        { provide: LessonService, useValue: lessonService },
+        { provide: KeycloakService, useValue: { hasRole: vi.fn().mockReturnValue(false) } },
+      ],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(LessonDetailPage);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const markdownContent = fixture.nativeElement.querySelector('.markdown-content') as HTMLElement;
+
+    expect(markdownContent.querySelector('h1')?.textContent).toBe('Safe heading');
+    expect(markdownContent.querySelector('script')).toBeNull();
+    expect(markdownContent.querySelector('img')?.hasAttribute('onerror')).toBe(false);
+  });
+});

--- a/src/TeacherSuite.Web/src/teacher-suite-ui/src/app/pages/lesson-detail/lesson-detail.ts
+++ b/src/TeacherSuite.Web/src/teacher-suite-ui/src/app/pages/lesson-detail/lesson-detail.ts
@@ -14,7 +14,6 @@ import {
   CourseGroup,
 } from '../../services/lesson.service';
 import { KeycloakService } from '../../auth/keycloak.service';
-import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { marked } from 'marked';
 
 @Component({
@@ -34,7 +33,7 @@ export class LessonDetailPage implements OnInit {
 
   lessonFiles: LessonFile[] = [];
   rawMarkdownContent: string | null = null;
-  markdownContent: SafeHtml | null = null;
+  markdownContent: string | null = null;
   downloadableFiles: LessonFile[] = [];
 
   showContextMenu = false;
@@ -61,8 +60,7 @@ export class LessonDetailPage implements OnInit {
     private lessonService: LessonService,
     private cdr: ChangeDetectorRef,
     private fb: FormBuilder,
-    private keycloakService: KeycloakService,
-    private sanitizer: DomSanitizer
+    private keycloakService: KeycloakService
   ) {
     this.attendanceForm = this.fb.group({
       groupId: ['', [Validators.required]],
@@ -118,14 +116,14 @@ export class LessonDetailPage implements OnInit {
             this.rawMarkdownContent = text;
             const html = marked.parse(text);
             if (typeof html === 'string') {
-              this.markdownContent = this.sanitizer.bypassSecurityTrustHtml(html);
+              this.markdownContent = html;
+              this.cdr.detectChanges();
             } else {
               (html as Promise<string>).then(h => {
-                this.markdownContent = this.sanitizer.bypassSecurityTrustHtml(h);
+                this.markdownContent = h;
                 this.cdr.detectChanges();
               });
             }
-            this.cdr.detectChanges();
           }).catch(() => {
             this.rawMarkdownContent = null;
             this.markdownContent = null;


### PR DESCRIPTION
### Motivation
- The lesson detail page previously used `DomSanitizer.bypassSecurityTrustHtml` on HTML produced from uploaded `.md` files which disables Angular's XSS protections and can allow script/event-handler payloads to run in users' browsers. 
- Restore safe rendering so uploaded markdown is sanitized by Angular's built-in sanitizer instead of being trusted unconditionally.

### Description
- Removed the `DomSanitizer` import and all uses of `bypassSecurityTrustHtml`, and changed `markdownContent` from `SafeHtml | null` to `string | null` so the parsed HTML is bound via `[innerHTML]` and sanitized by Angular. 
- Updated the markdown parsing flow to assign the output of `marked.parse(...)` (or the resolved promise) directly to `markdownContent` and to call `ChangeDetectorRef.detectChanges()` when appropriate. 
- Added a regression unit test `src/app/pages/lesson-detail/lesson-detail.spec.ts` that supplies malicious markdown containing a `<script>` and an `onerror` handler and asserts the script is removed and event-handler attributes are not present while safe markdown still renders. 
- Preserved the rest of the page behavior (file listing, downloads, suggestions/context menu) without introducing new dependencies.

### Testing
- Ran `git diff --check` which reported no whitespace errors. 
- Added the unit test file but could not run the test in this environment because `npm ci` / dependency installation did not complete and the Angular CLI binary (`ng`) was unavailable, so `npm test` could not be executed here. 
- To validate locally or in CI run `npm ci` in `src/TeacherSuite.Web/src/teacher-suite-ui` and then `npm test -- --watch=false --include src/app/pages/lesson-detail/lesson-detail.spec.ts` which should execute the added regression test.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35286d1f4c8322b1f6d422879abe7e)